### PR TITLE
String interning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +544,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0dd6aab3061be00b739299a1d8b10da43848f0d857b30f30ab83226680cd06"
 
 [[package]]
+name = "dashmap"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+dependencies = [
+ "cfg-if",
+ "num_cpus",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,8 +645,9 @@ dependencies = [
  "anyhow",
  "bitflags",
  "enum-map",
- "hashbrown",
+ "hashbrown 0.12.3",
  "k9",
+ "lasso",
  "num-derive",
  "num-traits",
  "option_set",
@@ -646,7 +666,7 @@ dependencies = [
  "enum-map",
  "erars-ast",
  "erars-lexer",
- "hashbrown",
+ "hashbrown 0.12.3",
  "k9",
  "log",
  "logos",
@@ -697,7 +717,7 @@ dependencies = [
  "bitflags",
  "cow-utils",
  "erars-ast",
- "hashbrown",
+ "hashbrown 0.12.3",
  "logos",
  "option_set",
  "serde",
@@ -718,7 +738,7 @@ dependencies = [
  "erars-ui",
  "erars-vm",
  "glob",
- "hashbrown",
+ "hashbrown 0.12.3",
  "log",
  "parking_lot",
  "rayon",
@@ -732,6 +752,7 @@ version = "0.1.0"
 dependencies = [
  "ansi_term",
  "anyhow",
+ "bincode",
  "clap 4.0.10",
  "erars-ast",
  "erars-compiler",
@@ -741,6 +762,7 @@ dependencies = [
  "flexi_logger",
  "log",
  "log-panics",
+ "rmp-serde",
  "ron",
 ]
 
@@ -769,6 +791,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arrayvec",
+ "bincode",
  "bitflags",
  "css-color",
  "derivative",
@@ -779,7 +802,7 @@ dependencies = [
  "erars-ui",
  "flate2",
  "glob",
- "hashbrown",
+ "hashbrown 0.12.3",
  "itertools",
  "k9",
  "log",
@@ -939,6 +962,16 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+ "serde",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -1065,7 +1098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1107,6 +1140,18 @@ dependencies = [
  "regex",
  "syn",
  "term_size",
+]
+
+[[package]]
+name = "lasso"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb7b21a526375c5ca55f1a6dfd4e1fad9fa4edd750f530252a718a44b2608f0"
+dependencies = [
+ "ahash",
+ "dashmap",
+ "hashbrown 0.11.2",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,6 +678,7 @@ dependencies = [
  "option_set",
  "serde",
  "smol_str",
+ "static_assertions",
  "strum",
  "thiserror",
  "unicode-xid",
@@ -1795,6 +1796,12 @@ checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,6 +650,7 @@ dependencies = [
  "lasso",
  "num-derive",
  "num-traits",
+ "once_cell",
  "option_set",
  "ordered-float",
  "serde",

--- a/crates/erars-ast/Cargo.toml
+++ b/crates/erars-ast/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0.142", features = ["derive"] }
 smol_str = { version = "0.1.23", features = ["serde"] }
 strum = { version = "0.24.1", features = ["derive"] }
 anyhow = { version = "1" }
+lasso = { version = "0.6.0", features = ["multi-threaded", "ahasher", "serialize"] }
 
 [dev-dependencies]
 k9 = "0.11.1"

--- a/crates/erars-ast/Cargo.toml
+++ b/crates/erars-ast/Cargo.toml
@@ -17,6 +17,7 @@ smol_str = { version = "0.1.23", features = ["serde"] }
 strum = { version = "0.24.1", features = ["derive"] }
 anyhow = { version = "1" }
 lasso = { version = "0.6.0", features = ["multi-threaded", "ahasher", "serialize"] }
+once_cell = "1.15.0"
 
 [dev-dependencies]
 k9 = "0.11.1"

--- a/crates/erars-ast/src/ast.rs
+++ b/crates/erars-ast/src/ast.rs
@@ -69,16 +69,16 @@ impl fmt::Display for ScriptPosition {
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Function {
     pub header: FunctionHeader,
     pub body: Vec<StmtWithPos>,
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FunctionHeader {
     pub file_path: SmolStr,
-    pub name: SmolStr,
+    pub name: StrKey,
     pub args: Vec<(Variable, Option<Value>)>,
     pub infos: Vec<FunctionInfo>,
 }

--- a/crates/erars-ast/src/ast.rs
+++ b/crates/erars-ast/src/ast.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use bitflags::bitflags;
 use ordered_float::NotNan;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use strum::{Display, EnumString};
 
@@ -11,7 +11,7 @@ use crate::{
     EventType, Interner, LocalVariable, StrKey, UnaryOperator, Value, Variable,
 };
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Stmt {
     Label(StrKey),
     SelectCase(
@@ -54,7 +54,7 @@ pub enum Stmt {
     Alignment(Alignment),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StmtWithPos(pub Stmt, pub ScriptPosition);
 
 #[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -69,13 +69,13 @@ impl fmt::Display for ScriptPosition {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Function {
     pub header: FunctionHeader,
     pub body: Vec<StmtWithPos>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FunctionHeader {
     pub file_path: SmolStr,
     pub name: StrKey,
@@ -83,7 +83,7 @@ pub struct FunctionHeader {
     pub infos: Vec<FunctionInfo>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum FunctionInfo {
     EventFlag(EventFlags),
     LocalSize(usize),
@@ -93,7 +93,7 @@ pub enum FunctionInfo {
     FunctionS,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Expr {
     String(StrKey),
     Int(i64),
@@ -149,14 +149,14 @@ impl Expr {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SelectCaseCond {
     Single(Expr),
     To(Expr, Expr),
     Is(BinaryOperator, Expr),
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FormExpr {
     pub expr: Expr,
     pub padding: Option<Expr>,
@@ -169,7 +169,7 @@ impl fmt::Debug for FormExpr {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Default)]
+#[derive(Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct FormText {
     pub first: StrKey,
     pub other: Vec<(FormExpr, StrKey)>,
@@ -223,7 +223,7 @@ option_set::option_set! {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, EnumString, Display)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, EnumString, Display, Serialize, Deserialize)]
 pub enum BeginType {
     #[strum(to_string = "TITLE")]
     Title,

--- a/crates/erars-ast/src/event.rs
+++ b/crates/erars-ast/src/event.rs
@@ -1,8 +1,7 @@
 use enum_map::Enum;
-use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString, IntoStaticStr};
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct Event {
     pub ty: EventType,
     pub flags: EventFlags,
@@ -38,7 +37,7 @@ impl Event {
     }
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum EventFlags {
     None,
     Pre,
@@ -46,20 +45,7 @@ pub enum EventFlags {
     Single,
 }
 
-#[derive(
-    Enum,
-    Clone,
-    Copy,
-    Debug,
-    Serialize,
-    Deserialize,
-    PartialEq,
-    Eq,
-    Hash,
-    Display,
-    EnumString,
-    IntoStaticStr,
-)]
+#[derive(Enum, Clone, Copy, Debug, PartialEq, Eq, Hash, Display, EnumString, IntoStaticStr)]
 pub enum EventType {
     #[strum(to_string = "EVENTFIRST")]
     First,

--- a/crates/erars-ast/src/event.rs
+++ b/crates/erars-ast/src/event.rs
@@ -1,7 +1,8 @@
 use enum_map::Enum;
+use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString, IntoStaticStr};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Event {
     pub ty: EventType,
     pub flags: EventFlags,
@@ -37,7 +38,7 @@ impl Event {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum EventFlags {
     None,
     Pre,
@@ -45,7 +46,20 @@ pub enum EventFlags {
     Single,
 }
 
-#[derive(Enum, Clone, Copy, Debug, PartialEq, Eq, Hash, Display, EnumString, IntoStaticStr)]
+#[derive(
+    Enum,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Display,
+    EnumString,
+    IntoStaticStr,
+    Serialize,
+    Deserialize,
+)]
 pub enum EventType {
     #[strum(to_string = "EVENTFIRST")]
     First,

--- a/crates/erars-ast/src/lib.rs
+++ b/crates/erars-ast/src/lib.rs
@@ -15,8 +15,68 @@ pub use ordered_float::NotNan;
 pub use value::Value;
 pub use variable::*;
 
-pub type StrKey = lasso::Spur;
+use once_cell::sync::Lazy;
+
 pub type Interner = lasso::ThreadedRodeo<StrKey>;
+
+pub static GLOBAL_INTERNER: Lazy<Interner> = Lazy::new(|| Interner::new());
+
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct StrKey(lasso::Spur);
+
+impl StrKey {
+    pub fn resolve(self) -> &'static str {
+        GLOBAL_INTERNER.resolve(&self)
+    }
+
+    pub fn new(s: &str) -> Self {
+        GLOBAL_INTERNER.get_or_intern(s)
+    }
+}
+
+impl std::fmt::Debug for StrKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(GLOBAL_INTERNER.resolve(&self))
+    }
+}
+
+impl std::fmt::Display for StrKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
+    }
+}
+
+impl serde::Serialize for StrKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.resolve().serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StrKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(Self::new(&s))
+    }
+}
+
+unsafe impl lasso::Key for StrKey {
+    #[inline(always)]
+    fn into_usize(self) -> usize {
+        self.0.into_usize()
+    }
+
+    #[inline(always)]
+    fn try_from_usize(int: usize) -> Option<Self> {
+        lasso::Spur::try_from_usize(int).map(Self)
+    }
+}
 
 pub fn var_name_alias(var: &str) -> &str {
     match var {

--- a/crates/erars-ast/src/lib.rs
+++ b/crates/erars-ast/src/lib.rs
@@ -15,6 +15,9 @@ pub use ordered_float::NotNan;
 pub use value::Value;
 pub use variable::*;
 
+pub type StrKey = lasso::Spur;
+pub type Interner = lasso::ThreadedRodeo<StrKey>;
+
 pub fn var_name_alias(var: &str) -> &str {
     match var {
         "MAXBASE" | "UPBASE" | "DOWNBASE" | "LOSEBASE" => "BASE",

--- a/crates/erars-ast/src/variable.rs
+++ b/crates/erars-ast/src/variable.rs
@@ -1,12 +1,9 @@
-use crate::{value::Value, Expr};
+use crate::{value::Value, Expr, StrKey};
 use serde::{Deserialize, Serialize};
-use smol_str::SmolStr;
 use strum::{Display, EnumString, IntoStaticStr};
 
 /// This variables are readonly system variables
-#[derive(
-    Clone, Copy, Debug, PartialEq, Eq, Display, EnumString, Serialize, Deserialize, IntoStaticStr,
-)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Display, EnumString, IntoStaticStr)]
 #[strum(serialize_all = "UPPERCASE")]
 pub enum BuiltinVariable {
     AblName,
@@ -64,21 +61,20 @@ pub enum BuiltinVariable {
     GamebaseInfo,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Variable {
-    pub var: Box<str>,
-    pub func_extern: Option<Box<str>>,
+    pub var: StrKey,
+    pub func_extern: Option<StrKey>,
     pub args: Vec<Expr>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LocalVariable {
-    pub var: SmolStr,
+    pub var: StrKey,
     pub info: VariableInfo,
 }
 
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(default)]
+#[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VariableInfo {
     pub is_chara: bool,
     pub is_str: bool,

--- a/crates/erars-ast/src/variable.rs
+++ b/crates/erars-ast/src/variable.rs
@@ -3,7 +3,9 @@ use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString, IntoStaticStr};
 
 /// This variables are readonly system variables
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Display, EnumString, IntoStaticStr)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Display, EnumString, IntoStaticStr, Serialize, Deserialize,
+)]
 #[strum(serialize_all = "UPPERCASE")]
 pub enum BuiltinVariable {
     AblName,
@@ -61,20 +63,21 @@ pub enum BuiltinVariable {
     GamebaseInfo,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Variable {
     pub var: StrKey,
     pub func_extern: Option<StrKey>,
     pub args: Vec<Expr>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LocalVariable {
     pub var: StrKey,
     pub info: VariableInfo,
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
 pub struct VariableInfo {
     pub is_chara: bool,
     pub is_str: bool,

--- a/crates/erars-compiler/Cargo.toml
+++ b/crates/erars-compiler/Cargo.toml
@@ -24,6 +24,7 @@ unicode-xid = "0.2.3"
 smol_str = { version = "0.1.23", features = ["serde"] }
 log = "0.4.17"
 derivative = "2.2.0"
+static_assertions = "1.1.0"
 
 [dev-dependencies]
 k9 = "0.11.1"

--- a/crates/erars-compiler/src/compiler.rs
+++ b/crates/erars-compiler/src/compiler.rs
@@ -1,6 +1,6 @@
 use crate::{CompileError, CompileResult, Instruction};
 use erars_ast::{
-    BinaryOperator, BuiltinVariable, Expr, FormExpr, FormText, Function, FunctionHeader, Interner,
+    BinaryOperator, BuiltinVariable, Expr, FormExpr, FormText, Function, FunctionHeader,
     SelectCaseCond, Stmt, StmtWithPos, StrKey, Variable,
 };
 use hashbrown::HashMap;

--- a/crates/erars-compiler/src/instruction.rs
+++ b/crates/erars-compiler/src/instruction.rs
@@ -3,6 +3,8 @@ use erars_ast::{
     EventType, NotNan, PrintFlags, ScriptPosition, StrKey, UnaryOperator,
 };
 
+static_assertions::assert_eq_size!(Instruction, (i64, i64));
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Instruction {
     Nop,

--- a/crates/erars-compiler/src/instruction.rs
+++ b/crates/erars-compiler/src/instruction.rs
@@ -1,10 +1,9 @@
 use erars_ast::{
     Alignment, BeginType, BinaryOperator, BuiltinCommand, BuiltinMethod, BuiltinVariable,
-    EventType, NotNan, PrintFlags, ScriptPosition, UnaryOperator,
+    EventType, NotNan, PrintFlags, ScriptPosition, StrKey, UnaryOperator,
 };
-use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Instruction {
     Nop,
     Pop,
@@ -15,7 +14,7 @@ pub enum Instruction {
     /// Duplicate second value in stack
     DuplicatePrev,
     LoadInt(i64),
-    LoadStr(Box<str>),
+    LoadStr(StrKey),
     EvalFormString,
     /// Padding first value
     ///
@@ -23,6 +22,8 @@ pub enum Instruction {
     PadStr(Alignment),
     LoadVarRef(u32),
     LoadExternVarRef(u32),
+    /// Load COUNT
+    LoadCountVarRef,
     /// Read VarRef into Value
     ///
     /// If value is not VarRef, This is noop

--- a/crates/erars-compiler/src/parser.rs
+++ b/crates/erars-compiler/src/parser.rs
@@ -722,6 +722,7 @@ impl ParserContext {
                 BuiltinCommand::Throw,
                 vec![try_nom!(lex, self::expr::normal_form_str(self)(left)).1],
             ),
+            Token::ReuseLastLine(left) => Stmt::ReuseLastLine(self.interner.get_or_intern(left)),
             Token::Print((flags, PrintType::Plain, form)) => {
                 Stmt::Print(flags, Expr::str(&self.interner, form))
             }

--- a/crates/erars-compiler/src/parser.rs
+++ b/crates/erars-compiler/src/parser.rs
@@ -3,11 +3,13 @@ mod expr;
 
 use erars_ast::{
     Alignment, BeginType, BinaryOperator, BuiltinCommand, EventFlags, EventType, Expr, Function,
-    FunctionHeader, FunctionInfo, ScriptPosition, Stmt, StmtWithPos, Variable, VariableInfo,
+    FunctionHeader, FunctionInfo, Interner, ScriptPosition, Stmt, StmtWithPos, StrKey, Variable,
+    VariableInfo,
 };
 use erars_lexer::{ConfigToken, ErhToken, JumpType, PrintType, Token};
 use hashbrown::{HashMap, HashSet};
 use logos::{internal::LexerInternal, Lexer};
+use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use std::{
     borrow::Cow,
@@ -68,7 +70,7 @@ macro_rules! try_nom {
 //     };
 // }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct CharacterTemplate {
     pub no: u32,
     pub is_assi: bool,
@@ -89,7 +91,7 @@ pub struct CharacterTemplate {
     pub relation: HashMap<u32, u32>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ReplaceInfo {
     pub money_unit: String,
     pub unit_forward: bool,
@@ -134,7 +136,7 @@ impl Default for ReplaceInfo {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Gamebase {
     pub code: u32,
     pub version: u32,
@@ -147,7 +149,7 @@ pub struct Gamebase {
     pub title: String,
 }
 
-#[derive(Clone, Debug, derivative::Derivative)]
+#[derive(Clone, Debug, derivative::Derivative, Serialize, Deserialize)]
 #[derivative(Default)]
 pub struct EraConfig {
     pub lang: Language,
@@ -201,7 +203,7 @@ impl EraConfig {
     }
 }
 
-#[derive(Clone, Copy, Debug, EnumString, Display)]
+#[derive(Clone, Copy, Debug, EnumString, Display, Serialize, Deserialize)]
 pub enum Language {
     #[strum(to_string = "JAPANESE")]
     Japanese,
@@ -219,7 +221,7 @@ impl Default for Language {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DefaultLocalVarSize {
     pub default_local_size: Option<usize>,
     pub default_locals_size: Option<usize>,
@@ -238,30 +240,56 @@ impl Default for DefaultLocalVarSize {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct HeaderInfo {
     pub macros: HashMap<String, String>,
     pub gamebase: Gamebase,
     pub replace: ReplaceInfo,
     pub character_templates: HashMap<u32, CharacterTemplate>,
     pub item_price: HashMap<u32, u32>,
-    pub var_names: HashMap<SmolStr, HashMap<SmolStr, u32>>,
-    pub var_name_var: HashMap<SmolStr, BTreeMap<u32, SmolStr>>,
-    pub global_variables: HashMap<SmolStr, VariableInfo>,
+    pub var_names: HashMap<StrKey, HashMap<StrKey, u32>>,
+    pub var_name_var: HashMap<StrKey, BTreeMap<u32, StrKey>>,
+    pub global_variables: HashMap<StrKey, VariableInfo>,
     pub default_local_size: DefaultLocalVarSize,
 }
 
 impl HeaderInfo {
-    pub fn merge_chara_csv(&mut self, s: &str) -> ParserResult<()> {
+    pub fn merge_chara_csv(&mut self, interner: &Interner, s: &str) -> ParserResult<()> {
         let mut lex = Lexer::new(s);
         let mut template = CharacterTemplate::default();
 
+        macro_rules! define_keys {
+            ($(
+                $name:ident = $str:expr;
+            )+) => {
+                $(
+                    let $name = interner.get_or_intern_static($str);
+                )+
+            };
+        }
+
+        define_keys! {
+            cstr = "CSTR";
+            talent = "TALENT";
+            base = "BASE";
+            mark = "MARK";
+            abl = "ABL";
+            exp = "EXP";
+            relation = "RELATION";
+            equip = "EQUIP";
+            cflag = "CFLAG";
+        }
+
         macro_rules! insert_template {
-            ($name:expr, $var:ident, $val1:expr, $val2:expr) => {{
+            ($var:ident, $val1:expr, $val2:expr) => {{
                 let idx = match $val1.parse::<u32>() {
                     Ok(idx) => idx,
                     Err(_) => {
-                        match self.var_names.get($name).and_then(|names| names.get($val1)).copied()
+                        match self
+                            .var_names
+                            .get(&$var)
+                            .and_then(|names| names.get(&interner.get_or_intern($val1)))
+                            .copied()
                         {
                             Some(idx) => idx,
                             None => error!(lex, "잘못된 숫자입니다."),
@@ -276,11 +304,15 @@ impl HeaderInfo {
 
                 template.$var.insert(idx, value);
             }};
-            (@bool $name:expr, $var:ident, $val1:expr, $val2:expr) => {{
+            (@bool $var:ident, $val1:expr, $val2:expr) => {{
                 let idx = match $val1.parse::<u32>() {
                     Ok(idx) => idx,
                     Err(_) => {
-                        match self.var_names.get($name).and_then(|names| names.get($val1)).copied()
+                        match self
+                            .var_names
+                            .get(&$var)
+                            .and_then(|names| names.get(&interner.get_or_intern($val1)))
+                            .copied()
                         {
                             Some(idx) => idx,
                             None => error!(lex, "잘못된 숫자입니다."),
@@ -289,11 +321,15 @@ impl HeaderInfo {
                 };
                 template.$var.insert(idx, 1);
             }};
-            (@str $name:expr, $var:ident, $val1:expr, $val2:expr) => {{
+            (@str $var:ident, $val1:expr, $val2:expr) => {{
                 let idx = match $val1.parse::<u32>() {
                     Ok(idx) => idx,
                     Err(_) => {
-                        match self.var_names.get($name).and_then(|names| names.get($val1)).copied()
+                        match self
+                            .var_names
+                            .get(&$var)
+                            .and_then(|names| names.get(&interner.get_or_intern($val1)))
+                            .copied()
                         {
                             Some(idx) => idx,
                             None => error!(lex, "잘못된 숫자입니다."),
@@ -313,17 +349,17 @@ impl HeaderInfo {
                 "あだ名" => template.nick_name = val1.into(),
                 "助手" => template.is_assi = val1.trim() == "1",
 
-                "CSTR" => insert_template!(@str "CSTR", cstr, val1, val2),
+                "CSTR" => insert_template!(@str cstr, val1, val2),
 
-                "素質" => insert_template!(@bool "TALENT", talent, val1, val2),
+                "素質" => insert_template!(@bool talent, val1, val2),
 
-                "基礎" => insert_template!("BASE", base, val1, val2),
-                "刻印" => insert_template!("MARK", mark, val1, val2),
-                "能力" => insert_template!("ABL", abl, val1, val2),
-                "経験" => insert_template!("EXP", exp, val1, val2),
-                "相性" => insert_template!("RELATION", relation, val1, val2),
-                "装着物" => insert_template!("EQUIP", equip, val1, val2),
-                "フラグ" => insert_template!("CFLAG", cflag, val1, val2),
+                "基礎" => insert_template!(base, val1, val2),
+                "刻印" => insert_template!(mark, val1, val2),
+                "能力" => insert_template!(abl, val1, val2),
+                "経験" => insert_template!(exp, val1, val2),
+                "相性" => insert_template!(relation, val1, val2),
+                "装着物" => insert_template!(equip, val1, val2),
+                "フラグ" => insert_template!(cflag, val1, val2),
                 other => log::warn!("Unknown character template name: {other}"),
             }
         }
@@ -379,13 +415,13 @@ impl HeaderInfo {
         Ok(())
     }
 
-    pub fn merge_name_csv(&mut self, var: &str, s: &str) -> ParserResult<()> {
+    pub fn merge_name_csv(&mut self, interner: &Interner, var: &str, s: &str) -> ParserResult<()> {
         let mut lex = Lexer::new(s);
-        let var = SmolStr::from(var);
+        let var = interner.get_or_intern(var);
         let mut name_var = BTreeMap::new();
 
-        while let Some((n, s)) = self::csv::name_csv_line(&mut lex)? {
-            self.var_names.entry(var.clone()).or_default().insert(s.clone(), n);
+        while let Some((n, s)) = self::csv::name_csv_line(interner, &mut lex)? {
+            self.var_names.entry(var).or_default().insert(s, n);
             name_var.insert(n, s);
         }
 
@@ -394,11 +430,11 @@ impl HeaderInfo {
         Ok(())
     }
 
-    pub fn merge_item_csv(&mut self, s: &str) -> ParserResult<()> {
+    pub fn merge_item_csv(&mut self, interner: &Interner, s: &str) -> ParserResult<()> {
         let mut lex = Lexer::new(s);
-        let var = SmolStr::new_inline("ITEM");
+        let var = interner.get_or_intern_static("ITEM");
 
-        while let Some((n, s, price)) = self::csv::name_item_line(&mut lex)? {
+        while let Some((n, s, price)) = self::csv::name_item_line(&interner, &mut lex)? {
             self.item_price.insert(n, price);
             self.var_names.entry(var.clone()).or_default().insert(s.clone(), n);
             self.var_name_var.entry(var.clone()).or_default().insert(n, s);
@@ -407,7 +443,7 @@ impl HeaderInfo {
         Ok(())
     }
 
-    pub fn merge_variable_size_csv(&mut self, s: &str) -> ParserResult<()> {
+    pub fn merge_variable_size_csv(&mut self, interner: &Interner, s: &str) -> ParserResult<()> {
         let mut lex = Lexer::new(s);
 
         while let Some((name, sizes)) = self::csv::variable_size_line(&mut lex)? {
@@ -429,8 +465,9 @@ impl HeaderInfo {
                         sizes.and_then(|v| v.first().copied())
                 }
                 name => {
+                    let name_key = interner.get_or_intern(name);
                     match sizes {
-                        Some(sizes) => match self.global_variables.get_mut(name) {
+                        Some(sizes) => match self.global_variables.get_mut(&name_key) {
                             Some(info) => {
                                 let info_len = info.size.len();
                                 if info.size.len() != sizes.len() {
@@ -448,7 +485,7 @@ impl HeaderInfo {
                         None => {
                             // FORBIDDEN
                             log::info!("Don't use {name}");
-                            self.global_variables.remove(name);
+                            self.global_variables.remove(&name_key);
                         }
                     }
                 }
@@ -572,8 +609,9 @@ impl HeaderInfo {
 
 #[derive(Debug)]
 pub struct ParserContext {
+    pub interner: Arc<Interner>,
     pub header: Arc<HeaderInfo>,
-    pub local_strs: RefCell<HashSet<SmolStr>>,
+    pub local_strs: RefCell<HashSet<StrKey>>,
     pub is_arg: Cell<bool>,
     pub ban_percent: Cell<bool>,
     pub file_path: SmolStr,
@@ -582,13 +620,14 @@ pub struct ParserContext {
 
 impl Default for ParserContext {
     fn default() -> Self {
-        Self::new(Arc::default(), "".into())
+        Self::new(Arc::default(), Arc::default(), "".into())
     }
 }
 
 impl ParserContext {
-    pub fn new(header: Arc<HeaderInfo>, file_path: SmolStr) -> Self {
+    pub fn new(interner: Arc<Interner>, header: Arc<HeaderInfo>, file_path: SmolStr) -> Self {
         Self {
+            interner,
             header,
             file_path,
             local_strs: RefCell::default(),
@@ -627,10 +666,12 @@ impl ParserContext {
         }
     }
 
-    pub fn is_str_var(&self, ident: &str) -> bool {
-        if matches!(ident, "LOCALS" | "ARGS") || self.local_strs.borrow().contains(ident) {
+    pub fn is_str_var(&self, key: StrKey) -> bool {
+        if matches!(self.interner.resolve(&key), "LOCALS" | "ARGS")
+            || self.local_strs.borrow().contains(&key)
+        {
             true
-        } else if let Some(v) = self.header.global_variables.get(ident) {
+        } else if let Some(v) = self.header.global_variables.get(&key) {
             v.is_str
         } else {
             false
@@ -659,7 +700,7 @@ impl ParserContext {
             Token::Alignment => Stmt::Alignment(take_ident!(Alignment, lex)),
             Token::Begin => Stmt::Begin(take_ident!(BeginType, lex)),
             Token::CallEvent => Stmt::CallEvent(take_ident!(EventType, lex)),
-            Token::LabelLine(label) => Stmt::Label(label.into()),
+            Token::LabelLine(label) => Stmt::Label(self.interner.get_or_intern(label)),
             Token::StrFormMethod((method, left)) => {
                 let (_, form) = try_nom!(lex, self::expr::normal_form_str(self)(left));
                 Stmt::Method(method, vec![form])
@@ -668,15 +709,18 @@ impl ParserContext {
                 let (_, form) = try_nom!(lex, self::expr::normal_form_str(self)(left));
                 Stmt::Command(com, vec![form])
             }
-            Token::CustomDrawLine(custom) => {
-                Stmt::Command(BuiltinCommand::CustomDrawLine, vec![Expr::str(custom)])
-            }
+            Token::CustomDrawLine(custom) => Stmt::Command(
+                BuiltinCommand::CustomDrawLine,
+                vec![Expr::str(&self.interner, custom)],
+            ),
             Token::Times(left) => try_nom!(lex, self::expr::times_line(self)(left)).1,
             Token::Throw(left) => Stmt::Command(
                 BuiltinCommand::Throw,
                 vec![try_nom!(lex, self::expr::normal_form_str(self)(left)).1],
             ),
-            Token::Print((flags, PrintType::Plain, form)) => Stmt::Print(flags, Expr::str(form)),
+            Token::Print((flags, PrintType::Plain, form)) => {
+                Stmt::Print(flags, Expr::str(&self.interner, form))
+            }
             Token::Print((flags, PrintType::Data, form)) => {
                 let form = form.trim();
                 let cond = if form.is_empty() {
@@ -688,7 +732,7 @@ impl ParserContext {
 
                 loop {
                     match self.next_token(lex)? {
-                        Some(Token::Data(data)) => list.push(vec![Expr::str(data)]),
+                        Some(Token::Data(data)) => list.push(vec![Expr::str(&self.interner, data)]),
                         Some(Token::DataForm(data)) => list.push(vec![
                             try_nom!(lex, self::expr::normal_form_str(self)(data)).1,
                         ]),
@@ -696,7 +740,9 @@ impl ParserContext {
                             let mut cur_list = Vec::new();
                             loop {
                                 match self.next_token(lex)? {
-                                    Some(Token::Data(data)) => cur_list.push(Expr::str(data)),
+                                    Some(Token::Data(data)) => {
+                                        cur_list.push(Expr::str(&self.interner, data))
+                                    }
                                     Some(Token::DataForm(data)) => cur_list.push(
                                         try_nom!(lex, self::expr::normal_form_str(self)(data)).1,
                                     ),
@@ -931,29 +977,25 @@ impl ParserContext {
 
                 Stmt::If(if_elses, block)
             }
-            Token::Inc => {
+            tok @ (Token::Inc | Token::Dec) => {
                 let ident = self.replace(take_ident!(lex));
                 let left = cut_line(lex);
-                let (left, func_extern) = try_nom!(lex, self::expr::var_func_extern(left));
+                let (left, func_extern) = try_nom!(lex, self::expr::var_func_extern(self, left));
                 let args = try_nom!(lex, self::expr::variable_arg(self, &ident)(left)).1;
                 let var = Variable {
-                    var: ident.into(),
+                    var: self.interner.get_or_intern(ident),
                     func_extern,
                     args,
                 };
-                Stmt::Assign(var, Some(BinaryOperator::Add), Expr::Int(1))
-            }
-            Token::Dec => {
-                let ident = self.replace(take_ident!(lex));
-                let left = cut_line(lex);
-                let (left, func_extern) = try_nom!(lex, self::expr::var_func_extern(left));
-                let args = try_nom!(lex, self::expr::variable_arg(self, &ident)(left)).1;
-                let var = Variable {
-                    var: ident.into(),
-                    func_extern,
-                    args,
-                };
-                Stmt::Assign(var, Some(BinaryOperator::Sub), Expr::Int(1))
+                Stmt::Assign(
+                    var,
+                    Some(if tok == Token::Inc {
+                        BinaryOperator::Add
+                    } else {
+                        BinaryOperator::Sub
+                    }),
+                    Expr::Int(1),
+                )
             }
             Token::Ident(var) => {
                 let i = cut_line(lex);

--- a/crates/erars-compiler/src/parser/csv.rs
+++ b/crates/erars-compiler/src/parser/csv.rs
@@ -1,6 +1,6 @@
+use erars_ast::{Interner, StrKey};
 use erars_lexer::CsvToken;
 use logos::Lexer;
-use smol_str::SmolStr;
 
 use crate::ParserResult;
 
@@ -24,8 +24,9 @@ pub fn csv2_line<'s>(
 }
 
 pub fn name_csv_line<'s>(
+    interner: &Interner,
     lex: &mut Lexer<'s, CsvToken<'s>>,
-) -> ParserResult<Option<(u32, SmolStr)>> {
+) -> ParserResult<Option<(u32, StrKey)>> {
     match lex.next() {
         Some(CsvToken::Csv2((idx, name))) => {
             let idx = match idx.parse::<u32>() {
@@ -33,7 +34,7 @@ pub fn name_csv_line<'s>(
                 Err(err) => return Err((format!("숫자가 와야합니다. :{err}"), lex.span())),
             };
 
-            Ok(Some((idx, name.into())))
+            Ok(Some((idx, interner.get_or_intern(name))))
         }
         Some(_) => Err((format!("CSV 형식이 잘못됐습니다."), lex.span())),
         None => Ok(None),
@@ -52,8 +53,9 @@ pub fn chara_line<'s>(
 }
 
 pub fn name_item_line<'s>(
+    interner: &Interner,
     lex: &mut Lexer<'s, CsvToken<'s>>,
-) -> ParserResult<Option<(u32, SmolStr, u32)>> {
+) -> ParserResult<Option<(u32, StrKey, u32)>> {
     match lex.next() {
         Some(CsvToken::Csv3((idx, name, price))) => {
             let idx = match idx.parse::<u32>() {
@@ -65,7 +67,7 @@ pub fn name_item_line<'s>(
                 Err(err) => return Err((format!("숫자가 와야합니다. :{err}"), lex.span())),
             };
 
-            Ok(Some((idx, name.into(), price)))
+            Ok(Some((idx, interner.get_or_intern(name), price)))
         }
         Some(_) => Err((format!("CSV 형식이 잘못됐습니다."), lex.span())),
         None => Ok(None),

--- a/crates/erars-http/src/http_frontend.rs
+++ b/crates/erars-http/src/http_frontend.rs
@@ -135,13 +135,17 @@ async fn start(
 }
 
 impl HttpFrontend {
-    pub fn run(&mut self, vm: TerminalVm, mut ctx: VmContext) -> anyhow::Result<()> {
+    pub fn run(
+        &mut self,
+        vm: TerminalVm,
+        mut ctx: VmContext,
+        mut vconsole: VirtualConsole,
+    ) -> anyhow::Result<()> {
         let rt = tokio::runtime::Builder::new_multi_thread().enable_all().build()?;
 
         let _guard = rt.enter();
         let (input_tx, input_rx) = bounded(8);
 
-        let mut vconsole = VirtualConsole::new(ctx.config.printc_width);
         let vconsole_buf = Arc::new(RwLock::new((
             VirtualConsole::new(ctx.config.printc_width),
             None,

--- a/crates/erars-http/src/main.rs
+++ b/crates/erars-http/src/main.rs
@@ -64,8 +64,8 @@ fn main() {
         None => Vec::new(),
     };
 
-    let (vm, ctx) = run_script(args.target_path, inputs).unwrap();
+    let (vm, ctx, vconsole) = run_script(args.target_path, inputs).unwrap();
 
     let mut frontend = http_frontend::HttpFrontend::new(args.port);
-    frontend.run(vm, ctx).unwrap();
+    frontend.run(vm, ctx, vconsole).unwrap();
 }

--- a/crates/erars-lexer/src/lib.rs
+++ b/crates/erars-lexer/src/lib.rs
@@ -34,12 +34,6 @@ pub fn parse_print_flags(mut s: &str) -> (&str, PrintFlags) {
     (s, flags)
 }
 
-unsafe fn parse_reuse(s: &str) -> Stmt {
-    let s = s.get_unchecked("REUSELASTLINE".len()..);
-
-    Stmt::ReuseLastLine(s.strip_prefix(' ').unwrap_or(s).into())
-}
-
 unsafe fn parse_print(s: &str) -> (PrintFlags, PrintType, &str) {
     // skip PRINT
     let mut s = s.get_unchecked("PRINT".len()..);
@@ -353,6 +347,8 @@ pub enum Token<'s> {
     Throw(&'s str),
     #[token("CUSTOMDRAWLINE", lex_line_left)]
     CustomDrawLine(&'s str),
+    #[regex("REUSELASTLINE", lex_line_left)]
+    ReuseLastLine(&'s str),
 
     #[token("RETURNFORM", |lex| normal_expr_command(lex, BuiltinCommand::Return))]
     #[token("PUTFORM", |lex| normal_expr_command(lex, BuiltinCommand::PutForm))]
@@ -452,7 +448,6 @@ pub enum Token<'s> {
     #[token("CSVCFLAG", |lex| normal_expr_method(lex, BuiltinMethod::CsvCflag))]
     NormalExprMethod((BuiltinMethod, &'s str)),
 
-    #[regex(r"REUSELASTLINE( [^\r\n]*)?", |lex| unsafe { parse_reuse(lex.slice()) })]
     #[token("GETTIME", |_| single_method(BuiltinMethod::GetTime))]
     #[token("GETFONT", |_| single_method(BuiltinMethod::GetFont))]
     #[token("GETCOLOR", |_| single_method(BuiltinMethod::GetColor))]

--- a/crates/erars-loader/src/lib.rs
+++ b/crates/erars-loader/src/lib.rs
@@ -78,7 +78,7 @@ fn read_file(path: &Path) -> std::io::Result<String> {
 pub fn run_script(
     target_path: String,
     inputs: Vec<Value>,
-) -> anyhow::Result<(TerminalVm, VmContext)> {
+) -> anyhow::Result<(TerminalVm, VmContext, VirtualConsole)> {
     let mut time = Instant::now();
 
     let config_path = format!("{target_path}/emuera.config");
@@ -106,6 +106,7 @@ pub fn run_script(
             time = Instant::now();
 
             tx.print_line(format!("[{}]: {}ms", $work, m));
+            log::info!("[{}]: {}ms", $work, m);
         };
     }
 
@@ -351,5 +352,5 @@ pub fn run_script(
 
     let vm = TerminalVm::new(function_dic, target_path.into());
 
-    Ok((vm, ctx))
+    Ok((vm, ctx, tx))
 }

--- a/crates/erars-stdio/Cargo.toml
+++ b/crates/erars-stdio/Cargo.toml
@@ -18,6 +18,8 @@ ron = "0.8.0"
 anyhow = "1.0.65"
 log = "0.4.17"
 ansi_term = "0.12.1"
+rmp-serde = "1.1.1"
+bincode = "1.3.3"
 
 [features]
 with-backtrace = ["log-panics/with-backtrace"]

--- a/crates/erars-stdio/src/main.rs
+++ b/crates/erars-stdio/src/main.rs
@@ -66,8 +66,8 @@ fn main() {
         None => Vec::new(),
     };
 
-    let (vm, mut ctx) = run_script(args.target_path, inputs).unwrap();
+    let (vm, mut ctx, tx) = run_script(args.target_path, inputs).unwrap();
 
-    let mut frontend = stdio_frontend::StdioFrontend::new(ctx.config.printc_width);
+    let mut frontend = stdio_frontend::StdioFrontend::new(tx);
     frontend.run(&vm, &mut ctx).unwrap();
 }

--- a/crates/erars-stdio/src/main.rs
+++ b/crates/erars-stdio/src/main.rs
@@ -1,10 +1,7 @@
 mod stdio_frontend;
 
-use std::{path::Path, time::Instant};
-
 use erars_ast::Value;
 use erars_loader::run_script;
-use erars_vm::{ScriptSaveFormat, ScriptSaveFormatRef, TerminalVm, VmContext};
 
 #[derive(clap::Parser)]
 #[clap(author, version, about)]
@@ -28,18 +25,15 @@ struct Args {
 
     #[clap(long, help = "Don't print logs")]
     quite: bool,
+    // #[clap(long, help = "Save script file")]
+    // save: bool,
 
-    #[clap(long, help = "Save script file")]
-    save: bool,
-
-    #[clap(long, help = "Load script file")]
-    load: bool,
+    // #[clap(long, help = "Load script file")]
+    // load: bool,
 }
 
 fn main() {
     use flexi_logger::*;
-
-    let time = Instant::now();
 
     let args: Args = clap::Parser::parse();
 
@@ -72,45 +66,8 @@ fn main() {
         None => Vec::new(),
     };
 
-    let (vm, mut ctx) = if args.load {
-        let format: ScriptSaveFormat = bincode::deserialize_from(std::io::BufReader::new(
-            std::fs::File::open("game.era").unwrap(),
-        ))
-        .unwrap();
+    let (vm, mut ctx) = run_script(args.target_path, inputs).unwrap();
 
-        log::info!("dic: {:?}", format.dic);
-
-        todo!();
-
-        (
-            TerminalVm {
-                dic: format.dic,
-                sav_path: Path::new(&args.target_path).join("sav"),
-            },
-            VmContext::new(format.header_info.into(), format.config.into()),
-        )
-    } else {
-        run_script(args.target_path, inputs).unwrap()
-    };
-
-    let diff = time.elapsed();
-    println!("Game load done! {}ms elapsed", diff.as_millis());
-
-    if args.save {
-        let time = Instant::now();
-        bincode::serialize_into(
-            &mut std::io::BufWriter::new(std::fs::File::create("game.era").unwrap()),
-            &ScriptSaveFormatRef {
-                dic: &vm.dic,
-                config: &ctx.config,
-                header_info: &ctx.header_info,
-            },
-        )
-        .unwrap();
-        let diff = time.elapsed();
-        println!("Save done! {}ms elapsed", diff.as_millis());
-    } else {
-        let mut frontend = stdio_frontend::StdioFrontend::new(ctx.config.printc_width);
-        frontend.run(&vm, &mut ctx).unwrap();
-    }
+    let mut frontend = stdio_frontend::StdioFrontend::new(ctx.config.printc_width);
+    frontend.run(&vm, &mut ctx).unwrap();
 }

--- a/crates/erars-stdio/src/main.rs
+++ b/crates/erars-stdio/src/main.rs
@@ -1,7 +1,10 @@
 mod stdio_frontend;
 
+use std::{path::Path, time::Instant};
+
 use erars_ast::Value;
 use erars_loader::run_script;
+use erars_vm::{ScriptSaveFormat, ScriptSaveFormatRef, TerminalVm, VmContext};
 
 #[derive(clap::Parser)]
 #[clap(author, version, about)]
@@ -25,10 +28,18 @@ struct Args {
 
     #[clap(long, help = "Don't print logs")]
     quite: bool,
+
+    #[clap(long, help = "Save script file")]
+    save: bool,
+
+    #[clap(long, help = "Load script file")]
+    load: bool,
 }
 
 fn main() {
     use flexi_logger::*;
+
+    let time = Instant::now();
 
     let args: Args = clap::Parser::parse();
 
@@ -61,7 +72,45 @@ fn main() {
         None => Vec::new(),
     };
 
-    let (vm, mut ctx) = run_script(args.target_path, inputs).unwrap();
-    let mut frontend = stdio_frontend::StdioFrontend::new(ctx.config.printc_width);
-    frontend.run(&vm, &mut ctx).unwrap();
+    let (vm, mut ctx) = if args.load {
+        let format: ScriptSaveFormat = bincode::deserialize_from(std::io::BufReader::new(
+            std::fs::File::open("game.era").unwrap(),
+        ))
+        .unwrap();
+
+        log::info!("dic: {:?}", format.dic);
+
+        todo!();
+
+        (
+            TerminalVm {
+                dic: format.dic,
+                sav_path: Path::new(&args.target_path).join("sav"),
+            },
+            VmContext::new(format.header_info.into(), format.config.into()),
+        )
+    } else {
+        run_script(args.target_path, inputs).unwrap()
+    };
+
+    let diff = time.elapsed();
+    println!("Game load done! {}ms elapsed", diff.as_millis());
+
+    if args.save {
+        let time = Instant::now();
+        bincode::serialize_into(
+            &mut std::io::BufWriter::new(std::fs::File::create("game.era").unwrap()),
+            &ScriptSaveFormatRef {
+                dic: &vm.dic,
+                config: &ctx.config,
+                header_info: &ctx.header_info,
+            },
+        )
+        .unwrap();
+        let diff = time.elapsed();
+        println!("Save done! {}ms elapsed", diff.as_millis());
+    } else {
+        let mut frontend = stdio_frontend::StdioFrontend::new(ctx.config.printc_width);
+        frontend.run(&vm, &mut ctx).unwrap();
+    }
 }

--- a/crates/erars-stdio/src/stdio_frontend.rs
+++ b/crates/erars-stdio/src/stdio_frontend.rs
@@ -7,10 +7,8 @@ pub struct StdioFrontend {
 }
 
 impl StdioFrontend {
-    pub fn new(printc_width: usize) -> Self {
-        Self {
-            vconsole: VirtualConsole::new(printc_width),
-        }
+    pub fn new(vconsole: VirtualConsole) -> Self {
+        Self { vconsole }
     }
 
     fn draw(&mut self, mut out: impl io::Write) -> anyhow::Result<()> {

--- a/crates/erars-vm/Cargo.toml
+++ b/crates/erars-vm/Cargo.toml
@@ -36,6 +36,7 @@ css-color = "0.2.4"
 regex = "1.6.0"
 twoway = "0.2.2"
 derivative = "2.2.0"
+bincode = "1.3.3"
 
 [dev-dependencies]
 k9 = "0.11.5"

--- a/crates/erars-vm/src/context.rs
+++ b/crates/erars-vm/src/context.rs
@@ -4,9 +4,10 @@ use smol_str::SmolStr;
 use std::fmt;
 use std::sync::Arc;
 
-use erars_ast::{BeginType, EventType, ScriptPosition, Value, VariableInfo, Interner};
+use erars_ast::{BeginType, EventType, Interner, ScriptPosition, StrKey, Value, VariableInfo};
 use erars_compiler::{EraConfig, HeaderInfo};
 
+use crate::variable::StrKeyLike;
 use crate::{SystemState, VariableStorage, VmVariable};
 
 use super::UniformVariable;
@@ -40,7 +41,11 @@ pub struct VmContext {
 }
 
 impl VmContext {
-    pub fn new(interner: Arc<Interner>, header_info: Arc<HeaderInfo>, config: Arc<EraConfig>) -> Self {
+    pub fn new(
+        interner: Arc<Interner>,
+        header_info: Arc<HeaderInfo>,
+        config: Arc<EraConfig>,
+    ) -> Self {
         let mut ret = Self {
             var: VariableStorage::new(interner, &header_info.global_variables),
             header_info,
@@ -112,6 +117,7 @@ impl VmContext {
     pub fn reduce_local_value(&mut self, value: LocalValue) -> Result<Value> {
         match value {
             LocalValue::Value(v) => Ok(v),
+            LocalValue::InternedStr(s) => Ok(self.var.resolve_key(s).into()),
             LocalValue::VarRef(r) => self.read_var_ref(&r),
         }
     }
@@ -128,7 +134,7 @@ impl VmContext {
 
         var.as_int()?
             .get_mut(idx)
-            .ok_or_else(|| anyhow::anyhow!("Variable {} out of index", var_ref.name))
+            .ok_or_else(|| anyhow::anyhow!("Variable {:?} out of index", var_ref.name))
     }
 
     pub fn set_var_ref(&mut self, var_ref: &VariableRef, value: Value) -> Result<()> {
@@ -141,7 +147,7 @@ impl VmContext {
         &'c mut self,
         r: &VariableRef,
     ) -> Result<(&'c mut VariableInfo, &'c mut VmVariable, usize)> {
-        self.var.index_maybe_local_var(&r.func_name, &r.name, &r.idxs)
+        self.var.index_maybe_local_var(r.func_name, r.name, &r.idxs)
     }
 
     pub fn resolve_var_ref_raw<'c>(
@@ -152,7 +158,7 @@ impl VmContext {
         &'c mut UniformVariable,
         ArrayVec<usize, 4>,
     )> {
-        let (info, var) = self.var.get_maybe_local_var(&r.func_name, &r.name)?;
+        let (info, var) = self.var.get_maybe_local_var(r.func_name, r.name)?;
 
         Ok((info, var, r.idxs.clone()))
     }
@@ -238,7 +244,7 @@ impl VmContext {
 
     pub fn take_arg_list(
         &mut self,
-        var_name: Option<&str>,
+        var_name: Option<StrKey>,
         count: u32,
     ) -> Result<ArrayVec<usize, 4>> {
         self.take_value_list(count)?
@@ -246,9 +252,13 @@ impl VmContext {
             .map(|value| match value {
                 Value::Int(i) => usize::try_from(i).map_err(anyhow::Error::from),
                 Value::String(str) => match var_name
+                    .map(|s| self.var.resolve_key(s))
                     .map(erars_ast::var_name_alias)
-                    .and_then(|var_name| self.header_info.var_names.get(var_name))
-                    .and_then(|names| names.get(str.as_str()))
+                    .map(|s| self.var.interner().get_or_intern(s))
+                    .and_then(|var_name| {
+                        self.header_info.var_names.get(&var_name.get_key(&self.var))
+                    })
+                    .and_then(|names| names.get(&str.get_key(&self.var)))
                 {
                     Some(value) => Ok(*value as usize),
                     None => anyhow::bail!("Can't index variable with String"),
@@ -264,9 +274,11 @@ impl VmContext {
             match arg {
                 LocalValue::Value(v) => ret.push(v),
                 LocalValue::VarRef(var) => {
-                    let var =
-                        self.var.index_maybe_local_var(&var.func_name, &var.name, &var.idxs)?;
+                    let var = self.var.index_maybe_local_var(var.func_name, var.name, &var.idxs)?;
                     ret.push(var.1.get(var.2)?);
+                }
+                LocalValue::InternedStr(s) => {
+                    ret.push(self.var.resolve_key(s).into());
                 }
             }
         }
@@ -288,13 +300,17 @@ impl VmContext {
         self.stack.push(prev);
     }
 
-    pub fn push_var_ref(&mut self, name: String, func_name: String, idxs: ArrayVec<usize, 4>) {
+    pub fn push_var_ref(&mut self, name: StrKey, func_name: StrKey, idxs: ArrayVec<usize, 4>) {
         let var_ref = VariableRef {
             func_name,
             name,
             idxs,
         };
         self.stack.push(LocalValue::VarRef(var_ref));
+    }
+
+    pub fn push_strkey(&mut self, key: StrKey) {
+        self.stack.push(LocalValue::InternedStr(key));
     }
 
     pub fn push(&mut self, value: impl Into<Value>) {
@@ -319,6 +335,7 @@ impl VmContext {
         match self.pop()? {
             LocalValue::Value(v) => Ok(v),
             LocalValue::VarRef(var_ref) => self.read_var_ref(&var_ref),
+            LocalValue::InternedStr(s) => Ok(Value::String(self.var.resolve_key(s).into())),
         }
     }
 
@@ -330,24 +347,28 @@ impl VmContext {
         self.pop_value().and_then(|v| v.try_into_str())
     }
 
+    pub fn pop_strkey(&mut self) -> Result<StrKey> {
+        let value = match self.pop()? {
+            LocalValue::InternedStr(s) => return Ok(s),
+            LocalValue::Value(v) => v,
+            LocalValue::VarRef(var_ref) => self.read_var_ref(&var_ref)?,
+        };
+
+        match value {
+            Value::Int(_) => bail!("Value is not Str"),
+            Value::String(s) => Ok(self.var.interner().get_or_intern(s)),
+        }
+    }
+
     pub fn pop_int(&mut self) -> Result<i64> {
         self.pop_value().and_then(|v| v.try_into_int())
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum FunctionIdentifier {
-    Normal(SmolStr),
+    Normal(StrKey),
     Event(EventType, usize),
-}
-
-impl FunctionIdentifier {
-    pub fn name(&self) -> &str {
-        match self {
-            Self::Normal(s) => s,
-            Self::Event(ty, _) => ty.into(),
-        }
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -361,14 +382,14 @@ pub struct Callstack {
 
 #[derive(Clone)]
 pub struct VariableRef {
-    pub name: String,
-    pub func_name: String,
+    pub name: StrKey,
+    pub func_name: StrKey,
     pub idxs: ArrayVec<usize, 4>,
 }
 
 impl fmt::Debug for VariableRef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}@{}", self.name, self.func_name)?;
+        write!(f, "{:?}@{:?}", self.name, self.func_name)?;
 
         for idx in self.idxs.iter() {
             write!(f, ":{}", idx)?;
@@ -380,7 +401,7 @@ impl fmt::Debug for VariableRef {
 
 impl fmt::Display for VariableRef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.name)?;
+        write!(f, "{:?}", self.name)?;
 
         for idx in self.idxs.iter() {
             write!(f, ":{}", idx)?;
@@ -393,6 +414,7 @@ impl fmt::Display for VariableRef {
 #[derive(Clone, Debug)]
 pub enum LocalValue {
     Value(Value),
+    InternedStr(StrKey),
     VarRef(VariableRef),
 }
 

--- a/crates/erars-vm/src/context.rs
+++ b/crates/erars-vm/src/context.rs
@@ -4,7 +4,7 @@ use smol_str::SmolStr;
 use std::fmt;
 use std::sync::Arc;
 
-use erars_ast::{BeginType, EventType, ScriptPosition, Value, VariableInfo};
+use erars_ast::{BeginType, EventType, ScriptPosition, Value, VariableInfo, Interner};
 use erars_compiler::{EraConfig, HeaderInfo};
 
 use crate::{SystemState, VariableStorage, VmVariable};
@@ -40,9 +40,9 @@ pub struct VmContext {
 }
 
 impl VmContext {
-    pub fn new(header_info: Arc<HeaderInfo>, config: Arc<EraConfig>) -> Self {
+    pub fn new(interner: Arc<Interner>, header_info: Arc<HeaderInfo>, config: Arc<EraConfig>) -> Self {
         let mut ret = Self {
-            var: VariableStorage::new(&header_info.global_variables),
+            var: VariableStorage::new(interner, &header_info.global_variables),
             header_info,
             state: vec![StateCallStack {
                 state: (BeginType::Title.into()),

--- a/crates/erars-vm/src/context.rs
+++ b/crates/erars-vm/src/context.rs
@@ -4,7 +4,7 @@ use smol_str::SmolStr;
 use std::fmt;
 use std::sync::Arc;
 
-use erars_ast::{BeginType, EventType, Interner, ScriptPosition, StrKey, Value, VariableInfo};
+use erars_ast::{BeginType, EventType, ScriptPosition, StrKey, Value, VariableInfo};
 use erars_compiler::{EraConfig, HeaderInfo};
 
 use crate::variable::StrKeyLike;
@@ -41,13 +41,9 @@ pub struct VmContext {
 }
 
 impl VmContext {
-    pub fn new(
-        interner: Arc<Interner>,
-        header_info: Arc<HeaderInfo>,
-        config: Arc<EraConfig>,
-    ) -> Self {
+    pub fn new(header_info: Arc<HeaderInfo>, config: Arc<EraConfig>) -> Self {
         let mut ret = Self {
-            var: VariableStorage::new(interner, &header_info.global_variables),
+            var: VariableStorage::new(&header_info.global_variables),
             header_info,
             state: vec![StateCallStack {
                 state: (BeginType::Title.into()),

--- a/crates/erars-vm/src/function.rs
+++ b/crates/erars-vm/src/function.rs
@@ -1,42 +1,42 @@
 use anyhow::{anyhow, Result};
 use arrayvec::ArrayVec;
 use enum_map::EnumMap;
+use erars_ast::StrKey;
 use erars_compiler::DefaultLocalVarSize;
 use hashbrown::HashMap;
 use smol_str::SmolStr;
 
 use erars_ast::{Event, EventFlags, EventType, Expr, FunctionInfo, Value, VariableInfo};
 use erars_compiler::{CompiledFunction, Instruction};
-use serde::{Deserialize, Serialize};
 
 use crate::VariableStorage;
 use crate::Workflow;
 
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct FunctionBody {
-    file_path: SmolStr,
-    is_function: bool,
-    is_functions: bool,
-    body: Box<[Instruction]>,
-    goto_labels: HashMap<SmolStr, u32>,
-    args: Vec<(Box<str>, Option<Value>, ArrayVec<usize, 4>)>,
+    pub file_path: SmolStr,
+    pub is_function: bool,
+    pub is_functions: bool,
+    pub goto_labels: HashMap<StrKey, u32>,
+    pub args: Vec<(StrKey, Option<Value>, ArrayVec<usize, 4>)>,
+    pub body: Box<[Instruction]>,
 }
 
 impl FunctionBody {
     pub fn push_arg(
         &mut self,
-        var: Box<str>,
+        var: StrKey,
         default_value: Option<Value>,
         indices: ArrayVec<usize, 4>,
     ) {
         self.args.push((var, default_value, indices));
     }
 
-    pub fn goto_labels(&self) -> &HashMap<SmolStr, u32> {
+    pub fn goto_labels(&self) -> &HashMap<StrKey, u32> {
         &self.goto_labels
     }
 
-    pub fn args(&self) -> &[(Box<str>, Option<Value>, ArrayVec<usize, 4>)] {
+    pub fn args(&self) -> &[(StrKey, Option<Value>, ArrayVec<usize, 4>)] {
         &self.args
     }
 
@@ -57,11 +57,11 @@ impl FunctionBody {
     }
 }
 
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct EventCollection {
-    single: Option<FunctionBody>,
-    events: Vec<FunctionBody>,
-    empty_count: usize,
+    pub single: Option<FunctionBody>,
+    pub events: Vec<FunctionBody>,
+    pub empty_count: usize,
 }
 
 impl EventCollection {
@@ -87,10 +87,10 @@ impl EventCollection {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FunctionDic {
-    normal: HashMap<SmolStr, FunctionBody>,
-    event: EnumMap<EventType, EventCollection>,
+    pub normal: HashMap<StrKey, FunctionBody>,
+    pub event: EnumMap<EventType, EventCollection>,
 }
 
 impl FunctionDic {
@@ -158,7 +158,7 @@ impl FunctionDic {
                     assert!(!body.is_function);
                 }
                 FunctionInfo::Dim(local) => {
-                    var_dic.add_local_info(header.name.clone(), local.var, local.info);
+                    var_dic.add_local_info(header.name, local.var, local.info);
                 }
             }
         }

--- a/crates/erars-vm/src/function.rs
+++ b/crates/erars-vm/src/function.rs
@@ -1,10 +1,9 @@
-use std::sync::Arc;
-
 use anyhow::{anyhow, Result};
 use arrayvec::ArrayVec;
 use enum_map::EnumMap;
 use erars_ast::Interner;
 use erars_ast::StrKey;
+use erars_ast::GLOBAL_INTERNER;
 use erars_compiler::DefaultLocalVarSize;
 use hashbrown::HashMap;
 use smol_str::SmolStr;
@@ -93,15 +92,15 @@ impl EventCollection {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FunctionDic {
-    pub interner: Arc<Interner>,
+    pub interner: &'static Interner,
     pub normal: HashMap<StrKey, FunctionBody>,
     pub event: EnumMap<EventType, EventCollection>,
 }
 
 impl FunctionDic {
-    pub fn new(interner: Arc<Interner>) -> Self {
+    pub fn new() -> Self {
         Self {
-            interner,
+            interner: &*GLOBAL_INTERNER,
             normal: HashMap::new(),
             event: EnumMap::default(),
         }

--- a/crates/erars-vm/src/lib.rs
+++ b/crates/erars-vm/src/lib.rs
@@ -18,6 +18,8 @@ pub use crate::{
     variable::{UniformVariable, VariableStorage, VmVariable},
 };
 
+pub use erars_compiler::{EraConfig, HeaderInfo, Instruction, Language};
+
 #[derive(Display, Debug, Clone, PartialEq, Eq)]
 pub enum Workflow {
     Return,

--- a/crates/erars-vm/src/system_func.rs
+++ b/crates/erars-vm/src/system_func.rs
@@ -228,7 +228,6 @@ impl SystemState {
                         }
                         tx.printrc(&format!(
                             "{name}[{no:3}]",
-                            name = ctx.var.resolve_key(train)
                         ));
                         *printc_count += 1;
                     }

--- a/crates/erars-vm/src/system_func.rs
+++ b/crates/erars-vm/src/system_func.rs
@@ -226,9 +226,7 @@ impl SystemState {
                             *printc_count = 0;
                             tx.new_line();
                         }
-                        tx.printrc(&format!(
-                            "{name}[{no:3}]",
-                        ));
+                        tx.printrc(&format!("{name}[{no:3}]",));
                         *printc_count += 1;
                     }
 

--- a/crates/erars-vm/src/system_func.rs
+++ b/crates/erars-vm/src/system_func.rs
@@ -438,7 +438,9 @@ fn load_savs(vm: &TerminalVm, ctx: &mut VmContext) -> HashMap<usize, Serializabl
     (0..SAVE_COUNT)
         .into_par_iter()
         .filter_map(|i| {
-            crate::save_data::read_save_data(&vm.sav_path(), &ctx.header_info, i as i64).ok().map(|d| (i, d))
+            crate::save_data::read_save_data(&vm.sav_path(), &ctx.header_info, i as i64)
+                .ok()
+                .map(|d| (i, d))
         })
         .collect()
 }

--- a/crates/erars-vm/src/terminal_vm.rs
+++ b/crates/erars-vm/src/terminal_vm.rs
@@ -5,13 +5,13 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::context::FunctionIdentifier;
 use crate::*;
+use crate::{context::FunctionIdentifier, variable::StrKeyLike};
 use anyhow::{anyhow, bail, Result};
 use arrayvec::ArrayVec;
 use erars_ast::{
     BeginType, BinaryOperator, BuiltinCommand, BuiltinMethod, BuiltinVariable, EventType,
-    PrintFlags, UnaryOperator, Value,
+    PrintFlags, StrKey, UnaryOperator, Value,
 };
 use erars_compiler::{Instruction, ParserContext, ReplaceInfo};
 use erars_ui::{FontStyle, InputRequest, InputRequestType, Timeout, VirtualConsole};
@@ -36,7 +36,7 @@ enum InstructionWorkflow {
     Exit,
     Goto(u32),
     GotoLabel {
-        label: String,
+        label: StrKey,
         is_try: bool,
     },
     Return,
@@ -77,7 +77,7 @@ impl TerminalVm {
         mut cursor: usize,
     ) -> Result<Workflow> {
         let insts = body.body();
-        let func_name = func_identifier.name();
+        let func_name = func_identifier.get_key(&ctx.var);
 
         while let Some(inst) = insts.get(cursor) {
             cursor += 1;
@@ -85,6 +85,7 @@ impl TerminalVm {
 
             log::trace!(
                 "[{func_name}] `{inst:?}[{cursor}]`, stack: {stack:?}, call_stack: {call_stack:?}",
+                func_name = ctx.var.resolve_key(func_name),
                 stack = ctx.stack(),
                 call_stack = ctx.call_stack(),
             );
@@ -95,7 +96,7 @@ impl TerminalVm {
                 Ok(Goto(pos)) => {
                     cursor = pos as usize;
                 }
-                Ok(GotoLabel { label, is_try }) => match body.goto_labels().get(label.as_str()) {
+                Ok(GotoLabel { label, is_try }) => match body.goto_labels().get(&label) {
                     Some(pos) => {
                         cursor = *pos as usize;
                     }
@@ -103,7 +104,10 @@ impl TerminalVm {
                         if is_try {
                             ctx.push(false);
                         } else {
-                            bail!("Label {label} is not founded");
+                            bail!(
+                                "Label {label} is not founded",
+                                label = ctx.var.resolve_key(label)
+                            );
                         }
                     }
                 },
@@ -210,18 +214,21 @@ impl TerminalVm {
 
     fn call_internal(
         &self,
-        label: &str,
+        label: StrKey,
         args: &[Value],
         tx: &mut VirtualConsole,
         ctx: &mut VmContext,
         body: &FunctionBody,
     ) -> Result<Workflow> {
-        log::trace!("CALL {label}({args:?})");
+        log::trace!(
+            "CALL {label}({args:?})",
+            label = ctx.var.interner().resolve(&label)
+        );
 
         let mut args = args.iter().cloned();
 
         for (var_idx, default_value, arg_indices) in body.args().iter() {
-            let (info, var) = ctx.var.get_maybe_local_var(label, var_idx)?;
+            let (info, var) = ctx.var.get_maybe_local_var(label, *var_idx)?;
             let var = var.assume_normal();
             let idx = info.calculate_single_idx(arg_indices).1;
 
@@ -242,7 +249,7 @@ impl TerminalVm {
             }
         }
 
-        let ret = self.run_body(FunctionIdentifier::Normal(label.into()), body, tx, ctx, 0)?;
+        let ret = self.run_body(FunctionIdentifier::Normal(label), body, tx, ctx, 0)?;
 
         Ok(ret)
     }
@@ -266,8 +273,11 @@ impl TerminalVm {
         tx: &mut VirtualConsole,
         ctx: &mut VmContext,
     ) -> Result<Option<Workflow>> {
-        match self.dic.get_func_opt(label) {
-            Some(body) => self.call_internal(label, args, tx, ctx, body).map(Some),
+        match ctx.var.interner().get(label) {
+            Some(label) => match self.dic.get_func_opt(label) {
+                Some(body) => self.call_internal(label, args, tx, ctx, body).map(Some),
+                None => Ok(None),
+            },
             None => Ok(None),
         }
     }
@@ -300,7 +310,7 @@ impl TerminalVm {
             log::info!("{stack:?}");
             match stack.func_name {
                 FunctionIdentifier::Normal(name) => {
-                    let body = self.dic.get_func(&name).unwrap();
+                    let body = self.dic.get_func(name)?;
                     match self.run_body(
                         FunctionIdentifier::Normal(name),
                         body,
@@ -423,7 +433,7 @@ impl TerminalVm {
                         report_error!(
                             tx,
                             "At function {func} {file}@{line}",
-                            func = call_stack.func_name.name(),
+                            func = call_stack.func_name.resolve_key(&ctx.var),
                             file = call_stack.file_path,
                             line = call_stack.script_position.line
                         );

--- a/crates/erars-vm/src/terminal_vm.rs
+++ b/crates/erars-vm/src/terminal_vm.rs
@@ -26,8 +26,8 @@ macro_rules! report_error {
 }
 
 pub struct TerminalVm {
-    dic: FunctionDic,
-    sav_path: PathBuf,
+    pub dic: FunctionDic,
+    pub sav_path: PathBuf,
 }
 
 #[derive(Debug)]

--- a/crates/erars-vm/src/terminal_vm/executor.rs
+++ b/crates/erars-vm/src/terminal_vm/executor.rs
@@ -64,11 +64,7 @@ pub(super) fn run_instruction(
         }
         Instruction::EvalFormString => {
             let form = ctx.pop_str()?;
-            let parser_ctx = ParserContext::new(
-                ctx.var.clone_interner(),
-                ctx.header_info.clone(),
-                "FORMS.ERB".into(),
-            );
+            let parser_ctx = ParserContext::new(ctx.header_info.clone(), "FORMS.ERB".into());
             let expr = erars_compiler::normal_form_str(&parser_ctx)(&form).unwrap().1;
             let insts = erars_compiler::compile_expr(expr).unwrap();
 

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -10,7 +10,7 @@ mod body {
                 r#"tests/parse_tests/bodys/alignment.erb"#,
                 ParserContext::parse_body_str
             ),
-            r#"
+            "
 [
     StmtWithPos(
         Alignment(
@@ -40,7 +40,7 @@ mod body {
         Print(
             NEWLINE,
             FormText(
-                {Var(Variable { var: "LOCALS", func_extern: None, args: [] })},
+                {Var(Variable { var: LOCALS, func_extern: None, args: [] })},
             ),
         ),
         ScriptPosition {
@@ -51,7 +51,7 @@ mod body {
         Print(
             NEWLINE,
             FormText(
-                {Var(Variable { var: "LOCALS", func_extern: None, args: [] })},
+                {Var(Variable { var: LOCALS, func_extern: None, args: [] })},
             ),
         ),
         ScriptPosition {
@@ -59,7 +59,7 @@ mod body {
         },
     ),
 ]
-"#
+"
         );
     }
 
@@ -70,12 +70,12 @@ mod body {
                 r#"tests/parse_tests/bodys/assign.erb"#,
                 ParserContext::parse_body_str
             ),
-            r#"
+            "
 [
     StmtWithPos(
         Assign(
             Variable {
-                var: "COUNT",
+                var: COUNT,
                 func_extern: None,
                 args: [
                     BinopExpr(
@@ -105,7 +105,7 @@ mod body {
         },
     ),
 ]
-"#
+"
         );
     }
 
@@ -116,12 +116,12 @@ mod body {
                 r#"tests/parse_tests/bodys/assign_add.erb"#,
                 ParserContext::parse_body_str
             ),
-            r#"
+            "
 [
     StmtWithPos(
         Assign(
             Variable {
-                var: "FLAG",
+                var: FLAG,
                 func_extern: None,
                 args: [
                     Int(
@@ -141,7 +141,7 @@ mod body {
         },
     ),
 ]
-"#
+"
         );
     }
 
@@ -152,12 +152,12 @@ mod body {
                 r#"tests/parse_tests/bodys/assign_str.erb"#,
                 ParserContext::parse_body_str
             ),
-            r#"
+            "
 [
     StmtWithPos(
         Assign(
             Variable {
-                var: "LOCALS",
+                var: LOCALS,
                 func_extern: None,
                 args: [],
             },
@@ -173,13 +173,13 @@ mod body {
     StmtWithPos(
         Assign(
             Variable {
-                var: "LOCALS",
+                var: LOCALS,
                 func_extern: None,
                 args: [],
             },
             None,
             FormText(
-                {Var(Variable { var: "LOCAL", func_extern: None, args: [Int(0)] })}.{BuiltinMethod(ToStr, [Var(Variable { var: "LOCAL", func_extern: None, args: [Int(1)] }), String("00")])},
+                {Var(Variable { var: LOCAL, func_extern: None, args: [Int(0)] })}.{BuiltinMethod(ToStr, [Var(Variable { var: LOCAL, func_extern: None, args: [Int(1)] }), String(00)])},
             ),
         ),
         ScriptPosition {
@@ -189,7 +189,7 @@ mod body {
     StmtWithPos(
         Assign(
             Variable {
-                var: "LOCALS",
+                var: LOCALS,
                 func_extern: None,
                 args: [],
             },
@@ -205,12 +205,12 @@ mod body {
     StmtWithPos(
         Assign(
             Variable {
-                var: "NICKNAME",
+                var: NICKNAME,
                 func_extern: None,
                 args: [
                     Var(
                         Variable {
-                            var: "MASTER",
+                            var: MASTER,
                             func_extern: None,
                             args: [],
                         },
@@ -219,7 +219,7 @@ mod body {
             },
             None,
             FormText(
-                {CondExpr(Var(Variable { var: "TALENT", func_extern: None, args: [Var(Variable { var: "MASTER", func_extern: None, args: [] }), Int(120)] }), FormText(신사), FormText(숙녀))},
+                {CondExpr(Var(Variable { var: TALENT, func_extern: None, args: [Var(Variable { var: MASTER, func_extern: None, args: [] }), Int(120)] }), FormText(신사), FormText(숙녀))},
             ),
         ),
         ScriptPosition {
@@ -229,7 +229,7 @@ mod body {
     StmtWithPos(
         Assign(
             Variable {
-                var: "LOCALS",
+                var: LOCALS,
                 func_extern: None,
                 args: [],
             },
@@ -243,7 +243,7 @@ mod body {
         },
     ),
 ]
-"#
+"
         );
     }
 
@@ -254,12 +254,12 @@ mod body {
                 r#"tests/parse_tests/bodys/call.erb"#,
                 ParserContext::parse_body_str
             ),
-            r#"
+            "
 [
     StmtWithPos(
         Call {
             name: String(
-                "FOO",
+                FOO,
             ),
             args: [
                 Int(
@@ -267,7 +267,7 @@ mod body {
                 ),
                 Var(
                     Variable {
-                        var: "A",
+                        var: A,
                         func_extern: None,
                         args: [
                             Int(
@@ -277,7 +277,7 @@ mod body {
                     },
                 ),
                 String(
-                    "123",
+                    123,
                 ),
             ],
             is_jump: false,
@@ -290,7 +290,7 @@ mod body {
         },
     ),
 ]
-"#
+"
         );
     }
 
@@ -301,14 +301,14 @@ mod body {
                 r#"tests/parse_tests/bodys/command.erb"#,
                 ParserContext::parse_body_str
             ),
-            r#"
+            "
 [
     StmtWithPos(
         Command(
             CustomDrawLine,
             [
                 String(
-                    "=",
+                    =,
                 ),
             ],
         ),
@@ -317,7 +317,7 @@ mod body {
         },
     ),
 ]
-"#
+"
         );
     }
 
@@ -328,12 +328,12 @@ mod body {
                 r#"tests/parse_tests/bodys/for.erb"#,
                 ParserContext::parse_body_str
             ),
-            r#"
+            "
 [
     StmtWithPos(
         For(
             Variable {
-                var: "COUNT",
+                var: COUNT,
                 func_extern: None,
                 args: [],
             },
@@ -355,7 +355,7 @@ mod body {
                         [
                             Var(
                                 Variable {
-                                    var: "COUNT",
+                                    var: COUNT,
                                     func_extern: None,
                                     args: [],
                                 },
@@ -373,7 +373,7 @@ mod body {
         },
     ),
 ]
-"#
+"
         );
     }
 
@@ -384,13 +384,13 @@ mod body {
                 r#"tests/parse_tests/bodys/hello.erb"#,
                 ParserContext::parse_body_str
             ),
-            r#"
+            "
 [
     StmtWithPos(
         Print(
             NEWLINE,
             String(
-                "Hello, world!",
+                Hello, world!,
             ),
         ),
         ScriptPosition {
@@ -398,7 +398,7 @@ mod body {
         },
     ),
 ]
-"#
+"
         );
     }
 
@@ -409,7 +409,7 @@ mod body {
                 r#"tests/parse_tests/bodys/if.erb"#,
                 ParserContext::parse_body_str
             ),
-            r#"
+            "
 [
     StmtWithPos(
         If(
@@ -418,7 +418,7 @@ mod body {
                     BinopExpr(
                         Var(
                             Variable {
-                                var: "A",
+                                var: A,
                                 func_extern: None,
                                 args: [],
                             },
@@ -433,7 +433,7 @@ mod body {
                             Print(
                                 (empty),
                                 String(
-                                    "A > 1",
+                                    A > 1,
                                 ),
                             ),
                             ScriptPosition {
@@ -446,7 +446,7 @@ mod body {
                     BinopExpr(
                         Var(
                             Variable {
-                                var: "A",
+                                var: A,
                                 func_extern: None,
                                 args: [],
                             },
@@ -461,7 +461,7 @@ mod body {
                             Print(
                                 (empty),
                                 String(
-                                    "A == 1",
+                                    A == 1,
                                 ),
                             ),
                             ScriptPosition {
@@ -476,7 +476,7 @@ mod body {
                     Print(
                         (empty),
                         String(
-                            "A < 1",
+                            A < 1,
                         ),
                     ),
                     ScriptPosition {
@@ -490,7 +490,7 @@ mod body {
         },
     ),
 ]
-"#
+"
         );
     }
 
@@ -501,12 +501,12 @@ mod body {
                 r#"tests/parse_tests/bodys/number.erb"#,
                 ParserContext::parse_body_str
             ),
-            r#"
+            "
 [
     StmtWithPos(
         Assign(
             Variable {
-                var: "LOCAL",
+                var: LOCAL,
                 func_extern: None,
                 args: [],
             },
@@ -522,7 +522,7 @@ mod body {
     StmtWithPos(
         Assign(
             Variable {
-                var: "LOCAL",
+                var: LOCAL,
                 func_extern: None,
                 args: [],
             },
@@ -538,7 +538,7 @@ mod body {
     StmtWithPos(
         Assign(
             Variable {
-                var: "LOCAL",
+                var: LOCAL,
                 func_extern: None,
                 args: [],
             },
@@ -554,7 +554,7 @@ mod body {
     StmtWithPos(
         Assign(
             Variable {
-                var: "LOCAL",
+                var: LOCAL,
                 func_extern: None,
                 args: [],
             },
@@ -570,7 +570,7 @@ mod body {
     StmtWithPos(
         Assign(
             Variable {
-                var: "LOCAL",
+                var: LOCAL,
                 func_extern: None,
                 args: [],
             },
@@ -586,7 +586,7 @@ mod body {
     StmtWithPos(
         Assign(
             Variable {
-                var: "LOCAL",
+                var: LOCAL,
                 func_extern: None,
                 args: [],
             },
@@ -605,7 +605,7 @@ mod body {
     StmtWithPos(
         Assign(
             Variable {
-                var: "LOCAL",
+                var: LOCAL,
                 func_extern: None,
                 args: [],
             },
@@ -624,7 +624,7 @@ mod body {
     StmtWithPos(
         Assign(
             Variable {
-                var: "LOCAL",
+                var: LOCAL,
                 func_extern: None,
                 args: [],
             },
@@ -641,7 +641,7 @@ mod body {
         },
     ),
 ]
-"#
+"
         );
     }
 
@@ -652,7 +652,7 @@ mod body {
                 r#"tests/parse_tests/bodys/print_data.erb"#,
                 ParserContext::parse_body_str
             ),
-            r#"
+            "
 [
     StmtWithPos(
         PrintData(
@@ -661,20 +661,20 @@ mod body {
             [
                 [
                     String(
-                        "data",
+                        data,
                     ),
                 ],
                 [
                     FormText(
-                        LOCAL={Var(Variable { var: "LOCAL", func_extern: None, args: [] })},
+                        LOCAL={Var(Variable { var: LOCAL, func_extern: None, args: [] })},
                     ),
                 ],
                 [
                     String(
-                        "list",
+                        list,
                     ),
                     String(
-                        "form",
+                        form,
                     ),
                 ],
             ],
@@ -684,7 +684,7 @@ mod body {
         },
     ),
 ]
-"#
+"
         );
     }
 
@@ -695,7 +695,7 @@ mod body {
                 r#"tests/parse_tests/bodys/print_simple.erb"#,
                 ParserContext::parse_body_str
             ),
-            r#"
+            "
 [
     StmtWithPos(
         Print(
@@ -712,7 +712,7 @@ mod body {
         Print(
             NEWLINE | WAIT,
             FormText(
-                {Method("조사처리", [Var(Variable { var: "CALLNAME", func_extern: None, args: [Method("GET_CHARA_M", [])] }), String("와")])} 같이 온 걸 보니, 단단히 각오하고 온 것 같다,
+                {Method(조사처리, [Var(Variable { var: CALLNAME, func_extern: None, args: [Method(GET_CHARA_M, [])] }), String(와)])} 같이 온 걸 보니, 단단히 각오하고 온 것 같다,
             ),
         ),
         ScriptPosition {
@@ -723,7 +723,7 @@ mod body {
         Print(
             NEWLINE,
             FormText(
-                {Var(Variable { var: "CALLNAME", func_extern: None, args: [Var(Variable { var: "ARG", func_extern: None, args: [] })] })}의 교습 관찰 결과 완료  결과：임시 성과치 {Var(Variable { var: "LOCAL", func_extern: None, args: [Int(0)] })}에 의한 실제 성과치 {Var(Variable { var: "LOCAL", func_extern: None, args: [Int(2)] })} 증가⇒{CondExpr(BinopExpr(Var(Variable { var: "LOCAL", func_extern: None, args: [Int(1)] }), Equal, Int(1)), FormText(성공), FormText(실패))}({Var(Variable { var: "CFLAG", func_extern: None, args: [Var(Variable { var: "ARG", func_extern: None, args: [] }), Int(693)] })}％) 작업 내용：{Var(Variable { var: "CFLAG", func_extern: None, args: [Var(Variable { var: "ARG", func_extern: None, args: [] }), Int(690)] })},
+                {Var(Variable { var: CALLNAME, func_extern: None, args: [Var(Variable { var: ARG, func_extern: None, args: [] })] })}의 교습 관찰 결과 완료  결과：임시 성과치 {Var(Variable { var: LOCAL, func_extern: None, args: [Int(0)] })}에 의한 실제 성과치 {Var(Variable { var: LOCAL, func_extern: None, args: [Int(2)] })} 증가⇒{CondExpr(BinopExpr(Var(Variable { var: LOCAL, func_extern: None, args: [Int(1)] }), Equal, Int(1)), FormText(성공), FormText(실패))}({Var(Variable { var: CFLAG, func_extern: None, args: [Var(Variable { var: ARG, func_extern: None, args: [] }), Int(693)] })}％) 작업 내용：{Var(Variable { var: CFLAG, func_extern: None, args: [Var(Variable { var: ARG, func_extern: None, args: [] }), Int(690)] })},
             ),
         ),
         ScriptPosition {
@@ -734,7 +734,7 @@ mod body {
         Print(
             NEWLINE | WAIT,
             FormText(
-                보지에서 애액을 흘렸{CondExpr(BinopExpr(Var(Variable { var: "TEQUIP", func_extern: None, args: [Int(42)] }), Equal, Int(0)), FormText(고, 작은 한숨을 토해냈), String(""))}다.,
+                보지에서 애액을 흘렸{CondExpr(BinopExpr(Var(Variable { var: TEQUIP, func_extern: None, args: [Int(42)] }), Equal, Int(0)), FormText(고, 작은 한숨을 토해냈), String())}다.,
             ),
         ),
         ScriptPosition {
@@ -742,7 +742,7 @@ mod body {
         },
     ),
 ]
-"#
+"
         );
     }
 
@@ -753,13 +753,13 @@ mod body {
                 r#"tests/parse_tests/bodys/printc.erb"#,
                 ParserContext::parse_body_str
             ),
-            r#"
+            "
 [
     StmtWithPos(
         Print(
             LEFT_ALIGN,
             String(
-                "LC",
+                LC,
             ),
         ),
         ScriptPosition {
@@ -770,7 +770,7 @@ mod body {
         Print(
             RIGHT_ALIGN,
             String(
-                "C",
+                C,
             ),
         ),
         ScriptPosition {
@@ -778,7 +778,7 @@ mod body {
         },
     ),
 ]
-"#
+"
         );
     }
 
@@ -789,7 +789,7 @@ mod body {
                 r#"tests/parse_tests/bodys/repeat.erb"#,
                 ParserContext::parse_body_str
             ),
-            r#"
+            "
 [
     StmtWithPos(
         Repeat(
@@ -801,12 +801,12 @@ mod body {
                 StmtWithPos(
                     Assign(
                         Variable {
-                            var: "MARK",
+                            var: MARK,
                             func_extern: None,
                             args: [
                                 Var(
                                     Variable {
-                                        var: "COUNT",
+                                        var: COUNT,
                                         func_extern: None,
                                         args: [],
                                     },
@@ -830,7 +830,7 @@ mod body {
                         BinopExpr(
                             Var(
                                 Variable {
-                                    var: "COUNT",
+                                    var: COUNT,
                                     func_extern: None,
                                     args: [],
                                 },
@@ -838,7 +838,7 @@ mod body {
                             Equal,
                             Var(
                                 Variable {
-                                    var: "MASTER",
+                                    var: MASTER,
                                     func_extern: None,
                                     args: [],
                                 },
@@ -860,12 +860,12 @@ mod body {
                         BinopExpr(
                             Var(
                                 Variable {
-                                    var: "CFLAG",
+                                    var: CFLAG,
                                     func_extern: None,
                                     args: [
                                         Var(
                                             Variable {
-                                                var: "COUNT",
+                                                var: COUNT,
                                                 func_extern: None,
                                                 args: [],
                                             },
@@ -899,7 +899,7 @@ mod body {
         },
     ),
 ]
-"#
+"
         );
     }
 
@@ -910,7 +910,7 @@ mod body {
                 r#"tests/parse_tests/bodys/selectcase.erb"#,
                 ParserContext::parse_body_str
             ),
-            r#"
+            "
 [
     StmtWithPos(
         SelectCase(
@@ -931,7 +931,7 @@ mod body {
                             Print(
                                 (empty),
                                 String(
-                                    "FOO",
+                                    FOO,
                                 ),
                             ),
                             ScriptPosition {
@@ -956,7 +956,7 @@ mod body {
                             Print(
                                 (empty),
                                 String(
-                                    "BAR",
+                                    BAR,
                                 ),
                             ),
                             ScriptPosition {
@@ -972,7 +972,7 @@ mod body {
                         Print(
                             (empty),
                             String(
-                                "BAZ",
+                                BAZ,
                             ),
                         ),
                         ScriptPosition {
@@ -987,7 +987,7 @@ mod body {
         },
     ),
 ]
-"#
+"
         );
     }
 
@@ -998,7 +998,7 @@ mod body {
                 r#"tests/parse_tests/bodys/sif.erb"#,
                 ParserContext::parse_body_str
             ),
-            r#"
+            "
 [
     StmtWithPos(
         Sif(
@@ -1009,7 +1009,7 @@ mod body {
                 Print(
                     (empty),
                     String(
-                        "45",
+                        45,
                     ),
                 ),
                 ScriptPosition {
@@ -1026,21 +1026,21 @@ mod body {
             BinopExpr(
                 Var(
                     Variable {
-                        var: "LOCALS",
+                        var: LOCALS,
                         func_extern: None,
                         args: [],
                     },
                 ),
                 NotEqual,
                 String(
-                    "",
+                    ,
                 ),
             ),
             StmtWithPos(
                 Print(
                     NEWLINE,
                     FormText(
-                        {Var(Variable { var: "LOCALS", func_extern: None, args: [] })},
+                        {Var(Variable { var: LOCALS, func_extern: None, args: [] })},
                     ),
                 ),
                 ScriptPosition {
@@ -1056,7 +1056,7 @@ mod body {
         Print(
             (empty),
             String(
-                "32",
+                32,
             ),
         ),
         ScriptPosition {
@@ -1064,7 +1064,7 @@ mod body {
         },
     ),
 ]
-"#
+"
         );
     }
 
@@ -1075,12 +1075,12 @@ mod body {
                 r#"tests/parse_tests/bodys/times.erb"#,
                 ParserContext::parse_body_str
             ),
-            r#"
+            "
 [
     StmtWithPos(
         Times(
             Variable {
-                var: "LOCAL",
+                var: LOCAL,
                 func_extern: None,
                 args: [],
             },
@@ -1093,7 +1093,7 @@ mod body {
         },
     ),
 ]
-"#
+"
         );
     }
 
@@ -1104,12 +1104,12 @@ mod body {
                 r#"tests/parse_tests/bodys/trailing_comma.erb"#,
                 ParserContext::parse_body_str
             ),
-            r#"
+            "
 [
     StmtWithPos(
         Call {
             name: String(
-                "CALLFUNC",
+                CALLFUNC,
             ),
             args: [
                 Int(
@@ -1129,7 +1129,7 @@ mod body {
         },
     ),
 ]
-"#
+"
         );
     }
 }
@@ -1144,12 +1144,12 @@ mod expr {
                 r#"tests/parse_tests/exprs/boolean.erb"#,
                 ParserContext::parse_expr_str
             ),
-            r#"
+            "
 BinopExpr(
     BinopExpr(
         Var(
             Variable {
-                var: "RESULT",
+                var: RESULT,
                 func_extern: None,
                 args: [],
             },
@@ -1163,12 +1163,12 @@ BinopExpr(
     BinopExpr(
         Var(
             Variable {
-                var: "TALENT",
+                var: TALENT,
                 func_extern: None,
                 args: [
                     Var(
                         Variable {
-                            var: "MASTER",
+                            var: MASTER,
                             func_extern: None,
                             args: [],
                         },
@@ -1185,7 +1185,7 @@ BinopExpr(
         ),
     ),
 )
-"#
+"
         );
     }
 
@@ -1196,7 +1196,7 @@ BinopExpr(
                 r#"tests/parse_tests/exprs/complex_op.erb"#,
                 ParserContext::parse_expr_str
             ),
-            r#"
+            "
 BinopExpr(
     BinopExpr(
         Int(
@@ -1210,12 +1210,12 @@ BinopExpr(
             Sub,
             Var(
                 Variable {
-                    var: "ABL",
+                    var: ABL,
                     func_extern: None,
                     args: [
                         Var(
                             Variable {
-                                var: "ARG",
+                                var: ARG,
                                 func_extern: None,
                                 args: [],
                             },
@@ -1244,7 +1244,7 @@ BinopExpr(
         ),
     ),
 )
-"#
+"
         );
     }
 
@@ -1278,10 +1278,10 @@ CondExpr(
                 r#"tests/parse_tests/exprs/csv.erb"#,
                 ParserContext::parse_expr_str
             ),
-            r#"
+            "
 Var(
     Variable {
-        var: "FLAG",
+        var: FLAG,
         func_extern: None,
         args: [
             Int(
@@ -1290,7 +1290,7 @@ Var(
         ],
     },
 )
-"#
+"
         );
     }
 
@@ -1301,19 +1301,19 @@ Var(
                 r#"tests/parse_tests/exprs/method.erb"#,
                 ParserContext::parse_expr_str
             ),
-            r#"
+            "
 Method(
-    "FOO",
+    FOO,
     [
         Int(
             123,
         ),
         String(
-            "BAR",
+            BAR,
         ),
         Var(
             Variable {
-                var: "LOCAL",
+                var: LOCAL,
                 func_extern: None,
                 args: [
                     Int(
@@ -1324,7 +1324,7 @@ Method(
         ),
     ],
 )
-"#
+"
         );
     }
 
@@ -1410,11 +1410,11 @@ BinopExpr(
                 r#"tests/parse_tests/exprs/str_literal.erb"#,
                 ParserContext::parse_expr_str
             ),
-            r#"
+            "
 String(
-    "",
+    ,
 )
-"#
+"
         );
     }
 
@@ -1425,9 +1425,9 @@ String(
                 r#"tests/parse_tests/exprs/trailing_comma.erb"#,
                 ParserContext::parse_expr_str
             ),
-            r#"
+            "
 Method(
-    "METHOD",
+    METHOD,
     [
         Int(
             1,
@@ -1437,7 +1437,7 @@ Method(
         ),
     ],
 )
-"#
+"
         );
     }
 
@@ -1448,10 +1448,10 @@ Method(
                 r#"tests/parse_tests/exprs/var_arg.erb"#,
                 ParserContext::parse_expr_str
             ),
-            r#"
+            "
 Var(
     Variable {
-        var: "COUNT",
+        var: COUNT,
         func_extern: None,
         args: [
             Int(
@@ -1460,7 +1460,7 @@ Var(
         ],
     },
 )
-"#
+"
         );
     }
 
@@ -1471,15 +1471,15 @@ Var(
                 r#"tests/parse_tests/exprs/var_complex.erb"#,
                 ParserContext::parse_expr_str
             ),
-            r#"
+            "
 Var(
     Variable {
-        var: "COUNT",
+        var: COUNT,
         func_extern: None,
         args: [
             Var(
                 Variable {
-                    var: "A",
+                    var: A,
                     func_extern: None,
                     args: [
                         Int(
@@ -1494,7 +1494,7 @@ Var(
         ],
     },
 )
-"#
+"
         );
     }
 
@@ -1505,15 +1505,15 @@ Var(
                 r#"tests/parse_tests/exprs/var_empty.erb"#,
                 ParserContext::parse_expr_str
             ),
-            r#"
+            "
 Var(
     Variable {
-        var: "COUNT",
+        var: COUNT,
         func_extern: None,
         args: [],
     },
 )
-"#
+"
         );
     }
 }
@@ -1532,7 +1532,7 @@ mod function {
 Function {
     header: FunctionHeader {
         file_path: "tests/parse_tests/functions/call.erb",
-        name: "FOO",
+        name: FOO,
         args: [],
         infos: [],
     },
@@ -1540,7 +1540,7 @@ Function {
         StmtWithPos(
             Assign(
                 Variable {
-                    var: "LOCALS",
+                    var: LOCALS,
                     func_extern: None,
                     args: [],
                 },
@@ -1556,7 +1556,7 @@ Function {
         StmtWithPos(
             Goto {
                 label: String(
-                    "LABEL",
+                    LABEL,
                 ),
                 catch_body: None,
             },
@@ -1567,7 +1567,7 @@ Function {
         StmtWithPos(
             Goto {
                 label: FormText(
-                    {Var(Variable { var: "LOCALS", func_extern: None, args: [] })},
+                    {Var(Variable { var: LOCALS, func_extern: None, args: [] })},
                 ),
                 catch_body: None,
             },
@@ -1578,7 +1578,7 @@ Function {
         StmtWithPos(
             Goto {
                 label: FormText(
-                    {Var(Variable { var: "LOCALS", func_extern: None, args: [] })},
+                    {Var(Variable { var: LOCALS, func_extern: None, args: [] })},
                 ),
                 catch_body: Some(
                     [],
@@ -1591,7 +1591,7 @@ Function {
         StmtWithPos(
             Goto {
                 label: FormText(
-                    {Var(Variable { var: "LOCALS", func_extern: None, args: [] })},
+                    {Var(Variable { var: LOCALS, func_extern: None, args: [] })},
                 ),
                 catch_body: Some(
                     [
@@ -1599,7 +1599,7 @@ Function {
                             Print(
                                 NEWLINE,
                                 String(
-                                    "CATCH",
+                                    CATCH,
                                 ),
                             ),
                             ScriptPosition {
@@ -1616,7 +1616,7 @@ Function {
         StmtWithPos(
             Call {
                 name: String(
-                    "BAR",
+                    BAR,
                 ),
                 args: [],
                 is_jump: false,
@@ -1631,7 +1631,7 @@ Function {
         StmtWithPos(
             Call {
                 name: String(
-                    "BAR",
+                    BAR,
                 ),
                 args: [],
                 is_jump: false,
@@ -1648,7 +1648,7 @@ Function {
         StmtWithPos(
             Call {
                 name: String(
-                    "BAR",
+                    BAR,
                 ),
                 args: [],
                 is_jump: false,
@@ -1665,7 +1665,7 @@ Function {
         StmtWithPos(
             Call {
                 name: String(
-                    "BAR",
+                    BAR,
                 ),
                 args: [],
                 is_jump: true,
@@ -1680,7 +1680,7 @@ Function {
         StmtWithPos(
             Call {
                 name: String(
-                    "BAR",
+                    BAR,
                 ),
                 args: [],
                 is_jump: true,
@@ -1714,7 +1714,7 @@ Function {
         StmtWithPos(
             Call {
                 name: String(
-                    "BAZ",
+                    BAZ,
                 ),
                 args: [
                     CondExpr(
@@ -1740,7 +1740,7 @@ Function {
         ),
         StmtWithPos(
             Label(
-                "LABEL",
+                LABEL,
             ),
             ScriptPosition {
                 line: 25,
@@ -1763,12 +1763,12 @@ Function {
 Function {
     header: FunctionHeader {
         file_path: "tests/parse_tests/functions/dim.erb",
-        name: "SYSTEM_TITLE",
+        name: SYSTEM_TITLE,
         args: [],
         infos: [
             Dim(
                 LocalVariable {
-                    var: "FOO",
+                    var: FOO,
                     info: VariableInfo {
                         is_chara: false,
                         is_str: false,
@@ -1793,7 +1793,7 @@ Function {
                 [
                     Var(
                         Variable {
-                            var: "FOO",
+                            var: FOO,
                             func_extern: None,
                             args: [],
                         },
@@ -1821,7 +1821,7 @@ Function {
 Function {
     header: FunctionHeader {
         file_path: "tests/parse_tests/functions/function.erb",
-        name: "FOO",
+        name: FOO,
         args: [],
         infos: [
             EventFlag(
@@ -1834,7 +1834,7 @@ Function {
             Print(
                 NEWLINE,
                 String(
-                    "Hello",
+                    Hello,
                 ),
             ),
             ScriptPosition {
@@ -1869,11 +1869,11 @@ Function {
 Function {
     header: FunctionHeader {
         file_path: "tests/parse_tests/functions/juel.erb",
-        name: "COMMON_MOVE_JUEL",
+        name: COMMON_MOVE_JUEL,
         args: [
             (
                 Variable {
-                    var: "ARG",
+                    var: ARG,
                     func_extern: None,
                     args: [],
                 },
@@ -1881,7 +1881,7 @@ Function {
             ),
             (
                 Variable {
-                    var: "ARG",
+                    var: ARG,
                     func_extern: None,
                     args: [
                         Int(
@@ -1893,7 +1893,7 @@ Function {
             ),
             (
                 Variable {
-                    var: "ARG",
+                    var: ARG,
                     func_extern: None,
                     args: [
                         Int(
@@ -1905,7 +1905,7 @@ Function {
             ),
             (
                 Variable {
-                    var: "ARG",
+                    var: ARG,
                     func_extern: None,
                     args: [
                         Int(
@@ -1917,7 +1917,7 @@ Function {
             ),
             (
                 Variable {
-                    var: "ARG",
+                    var: ARG,
                     func_extern: None,
                     args: [
                         Int(
@@ -1934,7 +1934,7 @@ Function {
         StmtWithPos(
             Assign(
                 Variable {
-                    var: "LOCAL",
+                    var: LOCAL,
                     func_extern: None,
                     args: [
                         Int(
@@ -1949,19 +1949,19 @@ Function {
                         BinopExpr(
                             Var(
                                 Variable {
-                                    var: "JUEL",
+                                    var: JUEL,
                                     func_extern: None,
                                     args: [
                                         Var(
                                             Variable {
-                                                var: "ARG",
+                                                var: ARG,
                                                 func_extern: None,
                                                 args: [],
                                             },
                                         ),
                                         Var(
                                             Variable {
-                                                var: "ARG",
+                                                var: ARG,
                                                 func_extern: None,
                                                 args: [
                                                     Int(
@@ -1976,7 +1976,7 @@ Function {
                             Add,
                             Var(
                                 Variable {
-                                    var: "ARG",
+                                    var: ARG,
                                     func_extern: None,
                                     args: [
                                         Int(
@@ -2011,7 +2011,7 @@ Function {
         StmtWithPos(
             Assign(
                 Variable {
-                    var: "LOCAL",
+                    var: LOCAL,
                     func_extern: None,
                     args: [
                         Int(
@@ -2023,7 +2023,7 @@ Function {
                 BinopExpr(
                     Var(
                         Variable {
-                            var: "LOCAL",
+                            var: LOCAL,
                             func_extern: None,
                             args: [
                                 Int(
@@ -2035,19 +2035,19 @@ Function {
                     Sub,
                     Var(
                         Variable {
-                            var: "JUEL",
+                            var: JUEL,
                             func_extern: None,
                             args: [
                                 Var(
                                     Variable {
-                                        var: "ARG",
+                                        var: ARG,
                                         func_extern: None,
                                         args: [],
                                     },
                                 ),
                                 Var(
                                     Variable {
-                                        var: "ARG",
+                                        var: ARG,
                                         func_extern: None,
                                         args: [
                                             Int(
@@ -2068,13 +2068,13 @@ Function {
         StmtWithPos(
             Assign(
                 Variable {
-                    var: "LOCALS",
+                    var: LOCALS,
                     func_extern: None,
                     args: [],
                 },
                 None,
                 FormText(
-                    {BuiltinVar(PalamName, [Var(Variable { var: "ARG", func_extern: None, args: [Int(1)] })])}의 구슬{CondExpr(BinopExpr(BinopExpr(Var(Variable { var: "ARG", func_extern: None, args: [Int(4)] }), Sub, BinopExpr(Var(Variable { var: "ARG", func_extern: None, args: [] }), NotEqual, Var(Variable { var: "TARGET", func_extern: None, args: [] }))), LessOrEqual, Int(0)), FormText(({Var(Variable { var: "CALLNAME", func_extern: None, args: [Var(Variable { var: "ARG", func_extern: None, args: [] })] })})), FormText())} {CondExpr(BinopExpr(BuiltinMethod(Sign, [Var(Variable { var: "LOCAL", func_extern: None, args: [Int(2)] })]), Equal, Int(1)), FormText(＋), FormText(－))} {BuiltinMethod(Abs, [Var(Variable { var: "LOCAL", func_extern: None, args: [Int(2)] })])},
+                    {BuiltinVar(PalamName, [Var(Variable { var: ARG, func_extern: None, args: [Int(1)] })])}의 구슬{CondExpr(BinopExpr(BinopExpr(Var(Variable { var: ARG, func_extern: None, args: [Int(4)] }), Sub, BinopExpr(Var(Variable { var: ARG, func_extern: None, args: [] }), NotEqual, Var(Variable { var: TARGET, func_extern: None, args: [] }))), LessOrEqual, Int(0)), FormText(({Var(Variable { var: CALLNAME, func_extern: None, args: [Var(Variable { var: ARG, func_extern: None, args: [] })] })})), FormText())} {CondExpr(BinopExpr(BuiltinMethod(Sign, [Var(Variable { var: LOCAL, func_extern: None, args: [Int(2)] })]), Equal, Int(1)), FormText(＋), FormText(－))} {BuiltinMethod(Abs, [Var(Variable { var: LOCAL, func_extern: None, args: [Int(2)] })])},
                 ),
             ),
             ScriptPosition {
@@ -2084,19 +2084,19 @@ Function {
         StmtWithPos(
             Assign(
                 Variable {
-                    var: "JUEL",
+                    var: JUEL,
                     func_extern: None,
                     args: [
                         Var(
                             Variable {
-                                var: "ARG",
+                                var: ARG,
                                 func_extern: None,
                                 args: [],
                             },
                         ),
                         Var(
                             Variable {
-                                var: "ARG",
+                                var: ARG,
                                 func_extern: None,
                                 args: [
                                     Int(
@@ -2110,7 +2110,7 @@ Function {
                 None,
                 Var(
                     Variable {
-                        var: "LOCAL",
+                        var: LOCAL,
                         func_extern: None,
                         args: [
                             Int(
@@ -2134,7 +2134,7 @@ Function {
                                 [
                                     Var(
                                         Variable {
-                                            var: "LOCAL",
+                                            var: LOCAL,
                                             func_extern: None,
                                             args: [
                                                 Int(
@@ -2155,7 +2155,7 @@ Function {
                                 SelectCase(
                                     Var(
                                         Variable {
-                                            var: "ARG",
+                                            var: ARG,
                                             func_extern: None,
                                             args: [
                                                 Int(
@@ -2179,7 +2179,7 @@ Function {
                                                         NEWLINE,
                                                         Var(
                                                             Variable {
-                                                                var: "LOCALS",
+                                                                var: LOCALS,
                                                                 func_extern: None,
                                                                 args: [],
                                                             },
@@ -2218,7 +2218,7 @@ Function {
                                                         NEWLINE | WAIT,
                                                         Var(
                                                             Variable {
-                                                                var: "LOCALS",
+                                                                var: LOCALS,
                                                                 func_extern: None,
                                                                 args: [],
                                                             },
@@ -2297,7 +2297,7 @@ mod program {
     Function {
         header: FunctionHeader {
             file_path: "tests/parse_tests/programs/call_form.erb",
-            name: "SYSTEM_TITLE",
+            name: SYSTEM_TITLE,
             args: [],
             infos: [],
         },
@@ -2326,11 +2326,11 @@ mod program {
     Function {
         header: FunctionHeader {
             file_path: "tests/parse_tests/programs/call_form.erb",
-            name: "FOO_123",
+            name: FOO_123,
             args: [
                 (
                     Variable {
-                        var: "ARG",
+                        var: ARG,
                         func_extern: None,
                         args: [],
                     },
@@ -2344,7 +2344,7 @@ mod program {
                 Print(
                     (empty),
                     FormText(
-                        FOO_{Var(Variable { var: "ARG", func_extern: None, args: [] })},
+                        FOO_{Var(Variable { var: ARG, func_extern: None, args: [] })},
                     ),
                 ),
                 ScriptPosition {
@@ -2370,7 +2370,7 @@ mod program {
     Function {
         header: FunctionHeader {
             file_path: "tests/parse_tests/programs/method_call.erb",
-            name: "FOO",
+            name: FOO,
             args: [],
             infos: [],
         },
@@ -2378,13 +2378,13 @@ mod program {
             StmtWithPos(
                 Assign(
                     Variable {
-                        var: "A",
+                        var: A,
                         func_extern: None,
                         args: [],
                     },
                     None,
                     Method(
-                        "BAR",
+                        BAR,
                         [],
                     ),
                 ),
@@ -2397,7 +2397,7 @@ mod program {
     Function {
         header: FunctionHeader {
             file_path: "tests/parse_tests/programs/method_call.erb",
-            name: "BAR",
+            name: BAR,
             args: [],
             infos: [
                 Function,
@@ -2436,7 +2436,7 @@ mod program {
     Function {
         header: FunctionHeader {
             file_path: "tests/parse_tests/programs/simple.erb",
-            name: "FOO",
+            name: FOO,
             args: [],
             infos: [],
         },
@@ -2445,7 +2445,7 @@ mod program {
                 Print(
                     (empty),
                     String(
-                        "foo",
+                        foo,
                     ),
                 ),
                 ScriptPosition {
@@ -2457,7 +2457,7 @@ mod program {
     Function {
         header: FunctionHeader {
             file_path: "tests/parse_tests/programs/simple.erb",
-            name: "FOO",
+            name: FOO,
             args: [],
             infos: [],
         },
@@ -2466,7 +2466,7 @@ mod program {
                 Print(
                     (empty),
                     String(
-                        "foo",
+                        foo,
                     ),
                 ),
                 ScriptPosition {
@@ -2478,7 +2478,7 @@ mod program {
     Function {
         header: FunctionHeader {
             file_path: "tests/parse_tests/programs/simple.erb",
-            name: "BAR",
+            name: BAR,
             args: [],
             infos: [],
         },
@@ -2487,7 +2487,7 @@ mod program {
                 Print(
                     (empty),
                     String(
-                        "bar",
+                        bar,
                     ),
                 ),
                 ScriptPosition {


### PR DESCRIPTION
Reduce memory usage by interning strings.


Make Instruction `Copy` required for zero copy deserialization of Function.