### PR TITLE
Use phf for strum (Speed +22%)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,7 +2417,9 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
+ "phf_macros",
  "phf_shared",
+ "proc-macro-hack",
 ]
 
 [[package]]
@@ -2438,6 +2440,20 @@ checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared",
  "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2572,6 +2588,12 @@ dependencies = [
  "quote",
  "version_check",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -3056,6 +3078,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
+ "phf",
  "strum_macros",
 ]
 

--- a/crates/erars-ast/Cargo.toml
+++ b/crates/erars-ast/Cargo.toml
@@ -13,7 +13,7 @@ num-traits = "0.2.15"
 option_set = "0.1.4"
 ordered-float = { version = "3.0.0", features = ["serde"] }
 serde = { version = "1.0.142", features = ["derive"] }
-strum = { version = "0.24.1", features = ["derive"] }
+strum = { version = "0.24.1", features = ["derive", "phf"] }
 anyhow = { version = "1" }
 lasso = { version = "0.6.0", features = ["multi-threaded", "ahasher", "serialize"] }
 

--- a/crates/erars-ast/src/alignment.rs
+++ b/crates/erars-ast/src/alignment.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use strum::EnumString;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, EnumString)]
+#[strum(use_phf)]
 #[repr(u32)]
 pub enum Alignment {
     #[strum(to_string = "LEFT")]

--- a/crates/erars-ast/src/ast.rs
+++ b/crates/erars-ast/src/ast.rs
@@ -251,6 +251,7 @@ option_set::option_set! {
 }
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, EnumString, Display, Serialize, Deserialize)]
+#[strum(use_phf)]
 #[repr(u32)]
 pub enum BeginType {
     #[strum(to_string = "TITLE")]

--- a/crates/erars-ast/src/command.rs
+++ b/crates/erars-ast/src/command.rs
@@ -5,6 +5,7 @@ use strum::{Display, EnumString, IntoStaticStr};
     Display, Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, IntoStaticStr, EnumString,
 )]
 #[strum(serialize_all = "UPPERCASE")]
+#[strum(use_phf)]
 #[serde(rename_all = "UPPERCASE")]
 #[allow(non_camel_case_types)]
 #[repr(u32)]
@@ -124,6 +125,7 @@ pub enum BuiltinMethod {
 
 #[derive(Display, Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, IntoStaticStr)]
 #[strum(serialize_all = "UPPERCASE")]
+#[strum(use_phf)]
 #[serde(rename_all = "UPPERCASE")]
 #[repr(u32)]
 #[allow(non_camel_case_types)]

--- a/crates/erars-ast/src/event.rs
+++ b/crates/erars-ast/src/event.rs
@@ -61,6 +61,7 @@ pub enum EventFlags {
     Deserialize,
     FromRepr,
 )]
+#[strum(use_phf)]
 #[repr(u32)]
 pub enum EventType {
     #[strum(to_string = "EVENTFIRST")]

--- a/crates/erars-ast/src/operator.rs
+++ b/crates/erars-ast/src/operator.rs
@@ -4,6 +4,7 @@ use strum::{Display, EnumString, IntoStaticStr};
 #[derive(
     Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, IntoStaticStr, Display, EnumString,
 )]
+#[strum(use_phf)]
 #[repr(u32)]
 pub enum UnaryOperator {
     /// !
@@ -17,6 +18,7 @@ pub enum UnaryOperator {
 #[derive(
     Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, IntoStaticStr, Display, EnumString,
 )]
+#[strum(use_phf)]
 #[repr(u32)]
 pub enum BinaryOperator {
     /// +

--- a/crates/erars-ast/src/variable.rs
+++ b/crates/erars-ast/src/variable.rs
@@ -7,6 +7,7 @@ use strum::{Display, EnumString, IntoStaticStr};
     Clone, Copy, Debug, PartialEq, Eq, Display, EnumString, IntoStaticStr, Serialize, Deserialize,
 )]
 #[strum(serialize_all = "UPPERCASE")]
+#[strum(use_phf)]
 #[repr(u32)]
 pub enum BuiltinVariable {
     CharaNum,

--- a/crates/erars-compiler/src/parser.rs
+++ b/crates/erars-compiler/src/parser.rs
@@ -164,6 +164,7 @@ pub struct Gamebase {
 }
 
 #[derive(Clone, Copy, Debug, Display, EnumString)]
+#[strum(use_phf)]
 pub enum EraConfigKey {
     #[strum(to_string = "内部で使用する東アジア言語")]
     Lang,

--- a/crates/erars-lexer/src/inst.rs
+++ b/crates/erars-lexer/src/inst.rs
@@ -6,6 +6,7 @@
     strum::IntoStaticStr,
     strum::EnumIter,
     strum::EnumCount,
+    strum::EnumString,
     num_derive::FromPrimitive,
     num_derive::ToPrimitive,
     Debug,
@@ -14,6 +15,7 @@
     PartialEq,
     Eq,
 )]
+#[strum(use_phf)]
 pub enum InstructionCode {
     CLEARLINE,
     REUSELASTLINE,

--- a/crates/erars-lexer/src/lib.rs
+++ b/crates/erars-lexer/src/lib.rs
@@ -5,6 +5,7 @@ pub mod utils;
 
 use std::ops::Range;
 
+use cow_utils::CowUtils;
 use logos::Logos;
 
 use erars_ast::*;
@@ -266,9 +267,9 @@ impl<'s> Preprocessor<'s> {
 
         let (ident, args) = utils::cut_ident(line);
 
-        if let Some(code) =
-            InstructionCode::iter().find(|code| ident.eq_ignore_ascii_case(<&str>::from(code)))
-        {
+        let ident_upper = ident.cow_to_ascii_uppercase();
+
+        if let Ok(code) = ident_upper.parse() {
             let args = match code {
                 InstructionCode::REUSELASTLINE | InstructionCode::THROW => {
                     args.strip_prefix(' ').unwrap_or(args)

--- a/crates/erars-vm/src/variable.rs
+++ b/crates/erars-vm/src/variable.rs
@@ -1210,6 +1210,7 @@ impl UniformVariable {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Enum, IntoStaticStr, Display)]
+#[strum(use_phf)]
 #[strum(serialize_all = "UPPERCASE")]
 pub enum KnownVariableNames {
     No,


### PR DESCRIPTION
# Bench results

```
small 5000              time:   [455.53 µs 457.28 µs 459.09 µs]
                        change: [-82.145% -81.987% -81.805%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe

small 50000             time:   [4.7716 ms 4.8044 ms 4.8394 ms]
                        change: [-81.590% -81.437% -81.268%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  9 (9.00%) high mild
  1 (1.00%) high severe

parse title             time:   [29.722 µs 29.914 µs 30.119 µs]
                        change: [-24.354% -23.723% -23.010%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe

parse system            time:   [838.89 µs 842.61 µs 846.95 µs]
                        change: [-25.281% -24.442% -23.684%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe

compile title           time:   [30.833 µs 30.983 µs 31.150 µs]
                        change: [-23.540% -22.718% -21.866%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

compile system          time:   [869.34 µs 874.13 µs 879.88 µs]
                        change: [-42.740% -41.112% -39.416%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  8 (8.00%) high mild
  2 (2.00%) high severe
```